### PR TITLE
Set up VPC and RDS with Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Terraform
+.terraform
+.terraform/
+*.tfplan
+*.tfstate
+*.tfstate.backup
+*.tfvars
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # noaa-flood-mapping
+
+- [Scripts](#scripts)
+
+## Scripts
+
+| Name                    | Description                                                 |
+| ----------------------- | ------------------------------------------------------------|
+| `infra`                 | Execute Terraform subcommands with remote state management. |

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,63 @@
+# Deployment
+
+- [AWS Credentials](#aws-credentials)
+- [Publish Container Images](#publish-container-images)
+- [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `noaa`:
+
+```bash
+$ aws configure --profile noaa
+AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
+AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+Default region name [None]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+First, we need to make sure there is a `terraform.tfvars` file in the project settings bucket on S3. The `.tfvars` file is where we can change specific attributes of the project's infrastructure, not defined in the `variables.tf` file.
+
+Here is an example `terraform.tfvars` for this project:
+
+```hcl
+project     = "Flood Mapping"
+environment = "Staging"
+aws_region  = "us-east-1"
+
+aws_key_name = "floodmapping-stg"
+
+r53_private_hosted_zone = "floodmapping.noaa.internal"
+
+external_access_cidr_block = "127.0.0.1/32"
+
+bastion_ami           = "ami-0a887e401f7654935"
+bastion_instance_type = "t3.nano"
+bastion_ebs_optimized = true
+
+rds_database_identifier = floodmapping-staging
+rds_database_name       = floodmapping
+rds_database_username   = floodmapping
+rds_database_password   = floodmapping
+```
+
+This file lives at `s3://floodmapping-staging-config-us-east-1/terraform/terraform.tfvars`.
+
+To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+$ docker-compose -f docker-compose.ci.yml run --rm terraform
+$ ./scripts/infra plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+$ ./scripts/infra apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -34,7 +34,7 @@ r53_private_hosted_zone = "floodmap.noaa.internal"
 
 external_access_cidr_block = "127.0.0.1/32"
 
-bastion_ami           = "ami-0a887e401f7654935"
+bastion_ami           = "ami-08f3d892de259504d"
 bastion_instance_type = "t3.nano"
 bastion_ebs_optimized = true
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -2,6 +2,8 @@
 
 - [AWS Credentials](#aws-credentials)
 - [Terraform](#terraform)
+- [Bastion](#bastion)
+  - [PostgreSQL Client](#postgresql-client)
 
 ## AWS Credentials
 
@@ -60,3 +62,13 @@ $ ./scripts/infra apply
 ```
 
 This will attempt to apply the plan assembled in the previous step using Amazon's APIs.
+
+## Bastion
+
+### PostgreSQL Client
+
+The bastion SSH host created by Terraform has several utility libraries installed on it, including a PostgreSQL 12 client. At the time that this client was installed, PostgreSQL 12 support was new to RDS and the client for 12 was not available on the `amazon-linux-extras` repository.
+
+To perform an upgrade, the existing `postgresql12`, `libpq5`, and `postgresql12-libs` packages should be uninstalled and the newer versions should be installed from [this repository](https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-7-x86_64/).
+
+When `amazon-linux-extras` adds PostgreSQL 12 libraries, the manually installed RPMs can be replaced with the packages in `amazon-linux-extras`.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,7 +1,6 @@
 # Deployment
 
 - [AWS Credentials](#aws-credentials)
-- [Publish Container Images](#publish-container-images)
 - [Terraform](#terraform)
 
 ## AWS Credentials
@@ -25,13 +24,13 @@ First, we need to make sure there is a `terraform.tfvars` file in the project se
 Here is an example `terraform.tfvars` for this project:
 
 ```hcl
-project     = "Flood Mapping"
+project     = "Flood Map"
 environment = "Staging"
 aws_region  = "us-east-1"
 
-aws_key_name = "floodmapping-stg"
+aws_key_name = "floodmap-stg"
 
-r53_private_hosted_zone = "floodmapping.noaa.internal"
+r53_private_hosted_zone = "floodmap.noaa.internal"
 
 external_access_cidr_block = "127.0.0.1/32"
 
@@ -39,13 +38,13 @@ bastion_ami           = "ami-0a887e401f7654935"
 bastion_instance_type = "t3.nano"
 bastion_ebs_optimized = true
 
-rds_database_identifier = floodmapping-staging
-rds_database_name       = floodmapping
-rds_database_username   = floodmapping
-rds_database_password   = floodmapping
+rds_database_identifier = floodmap-staging
+rds_database_name       = floodmap
+rds_database_username   = floodmap
+rds_database_password   = floodmap
 ```
 
-This file lives at `s3://floodmapping-staging-config-us-east-1/terraform/terraform.tfvars`.
+This file lives at `s3://floodmap-staging-config-us-east-1/terraform/terraform.tfvars`.
 
 To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -44,7 +44,7 @@ rds_database_username   = floodmap
 rds_database_password   = floodmap
 ```
 
-This file lives at `s3://floodmap-staging-config-us-east-1/terraform/terraform.tfvars`.
+This file lives at `s3://noaafloodmap-staging-config-us-east-1/terraform/terraform.tfvars`.
 
 To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 

--- a/deployment/terraform/alarms.tf
+++ b/deployment/terraform/alarms.tf
@@ -1,0 +1,3 @@
+resource "aws_sns_topic" "global" {
+  name = "topic${replace(var.project, " ", "")}${var.environment}GlobalNotifications"
+}

--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region  = var.aws_region
+  version = "~> 2.70.0"
+}
+
+terraform {
+  backend "s3" {
+    region  = "us-east-1"
+    encrypt = "true"
+  }
+}

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -88,6 +88,7 @@ module "database" {
   storage_encrypted          = var.rds_storage_encrypted
   subnet_group               = aws_db_subnet_group.default.name
   parameter_group            = aws_db_parameter_group.default.name
+  deletion_protection        = var.rds_deletion_protection
 
   alarm_cpu_threshold                = var.rds_cpu_threshold_percent
   alarm_disk_queue_threshold         = var.rds_disk_queue_threshold

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -1,0 +1,103 @@
+#
+# RDS resources
+#
+resource "aws_db_subnet_group" "default" {
+  name        = var.rds_database_identifier
+  description = "Private subnets for the RDS instances"
+  subnet_ids  = module.vpc.private_subnet_ids
+
+  tags = {
+    Name        = "dbsngDatabaseServer"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_db_parameter_group" "default" {
+  name        = var.rds_database_identifier
+  description = "Parameter group for the RDS instances"
+  family      = var.rds_parameter_group_family
+
+  parameter {
+    name  = "seq_page_cost"
+    value = var.rds_seq_page_cost
+  }
+
+  parameter {
+    name  = "random_page_cost"
+    value = var.rds_random_page_cost
+  }
+
+  parameter {
+    name  = "log_min_duration_statement"
+    value = var.rds_log_min_duration_statement
+  }
+
+  parameter {
+    name  = "log_connections"
+    value = var.rds_log_connections
+  }
+
+  parameter {
+    name  = "log_disconnections"
+    value = var.rds_log_disconnections
+  }
+
+  parameter {
+    name  = "log_lock_waits"
+    value = var.rds_log_lock_waits
+  }
+
+  parameter {
+    name  = "log_temp_files"
+    value = var.rds_log_temp_files
+  }
+
+  parameter {
+    name  = "log_autovacuum_min_duration"
+    value = var.rds_log_autovacuum_min_duration
+  }
+
+  tags = {
+    Name        = "dbpgDatabaseServer"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+module "database" {
+  source = "github.com/azavea/terraform-aws-postgresql-rds?ref=3.0.0"
+
+  vpc_id                     = module.vpc.id
+  allocated_storage          = var.rds_allocated_storage
+  engine_version             = var.rds_engine_version
+  instance_type              = var.rds_instance_type
+  storage_type               = var.rds_storage_type
+  database_identifier        = var.rds_database_identifier
+  database_name              = var.rds_database_name
+  database_username          = var.rds_database_username
+  database_password          = var.rds_database_password
+  backup_retention_period    = var.rds_backup_retention_period
+  backup_window              = var.rds_backup_window
+  maintenance_window         = var.rds_maintenance_window
+  auto_minor_version_upgrade = var.rds_auto_minor_version_upgrade
+  final_snapshot_identifier  = var.rds_final_snapshot_identifier
+  skip_final_snapshot        = var.rds_skip_final_snapshot
+  copy_tags_to_snapshot      = var.rds_copy_tags_to_snapshot
+  multi_availability_zone    = var.rds_multi_az
+  storage_encrypted          = var.rds_storage_encrypted
+  subnet_group               = aws_db_subnet_group.default.name
+  parameter_group            = aws_db_parameter_group.default.name
+
+  alarm_cpu_threshold                = var.rds_cpu_threshold_percent
+  alarm_disk_queue_threshold         = var.rds_disk_queue_threshold
+  alarm_free_disk_threshold          = var.rds_free_disk_threshold_bytes
+  alarm_free_memory_threshold        = var.rds_free_memory_threshold_bytes
+  alarm_cpu_credit_balance_threshold = var.rds_cpu_credit_balance_threshold
+  alarm_actions                      = [aws_sns_topic.global.arn]
+  ok_actions                         = [aws_sns_topic.global.arn]
+  insufficient_data_actions          = [aws_sns_topic.global.arn]
+
+  project     = var.project
+  environment = var.environment
+}

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -1,0 +1,24 @@
+#
+# Private DNS resources
+#
+resource "aws_route53_zone" "internal" {
+  name = var.r53_private_hosted_zone
+
+  vpc {
+    vpc_id     = module.vpc.id
+    vpc_region = var.aws_region
+  }
+
+  tags = {
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_route53_record" "database" {
+  zone_id = aws_route53_zone.internal.zone_id
+  name    = "database.service.${var.r53_private_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "10"
+  records = [module.database.hostname]
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -1,0 +1,12 @@
+#
+# Bastion security group resources
+#
+resource "aws_security_group_rule" "bastion_ssh_ingress" {
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = [var.external_access_cidr_block]
+
+  security_group_id = module.vpc.bastion_security_group_id
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -10,3 +10,26 @@ resource "aws_security_group_rule" "bastion_ssh_ingress" {
 
   security_group_id = module.vpc.bastion_security_group_id
 }
+
+resource "aws_security_group_rule" "bastion_rds_egress" {
+  type      = "egress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = module.vpc.bastion_security_group_id
+  source_security_group_id = module.database.database_security_group_id
+}
+
+#
+# RDS security group resources
+#
+resource "aws_security_group_rule" "rds_bastion_ingress" {
+  type      = "ingress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = module.database.database_security_group_id
+  source_security_group_id = module.vpc.bastion_security_group_id
+}

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,0 +1,17 @@
+module "vpc" {
+  source = "github.com/azavea/terraform-aws-vpc?ref=6.0.0"
+
+  name                       = "vpc${replace(var.project, " ", "")}${var.environment}"
+  region                     = var.aws_region
+  key_name                   = var.aws_key_name
+  cidr_block                 = var.vpc_cidr_block
+  private_subnet_cidr_blocks = var.vpc_private_subnet_cidr_blocks
+  public_subnet_cidr_blocks  = var.vpc_public_subnet_cidr_blocks
+  availability_zones         = var.aws_availability_zones
+  bastion_ami                = var.bastion_ami
+  bastion_instance_type      = var.bastion_instance_type
+  bastion_ebs_optimized      = var.bastion_ebs_optimized
+
+  project     = var.project
+  environment = var.environment
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -12,3 +12,45 @@ variable "aws_region" {
   default = "us-east-1"
   type    = string
 }
+
+variable "aws_availability_zones" {
+  default = ["us-east-1a", "us-east-1b"]
+  type    = list(string)
+}
+
+variable "aws_key_name" {
+  type = string
+}
+
+variable "vpc_cidr_block" {
+  default = "10.0.0.0/16"
+  type    = string
+}
+
+variable "external_access_cidr_block" {
+  type = string
+}
+
+variable "vpc_private_subnet_cidr_blocks" {
+  default = ["10.0.1.0/24", "10.0.3.0/24"]
+  type    = list(string)
+}
+
+variable "vpc_public_subnet_cidr_blocks" {
+  default = ["10.0.0.0/24", "10.0.2.0/24"]
+  type    = list(string)
+}
+
+variable "bastion_ami" {
+  type = string
+}
+
+variable "bastion_instance_type" {
+  default = "t3.nano"
+  type    = string
+}
+
+variable "bastion_ebs_optimized" {
+  default = true
+  type    = bool
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -22,6 +22,10 @@ variable "aws_key_name" {
   type = string
 }
 
+variable "r53_private_hosted_zone" {
+  type = string
+}
+
 variable "vpc_cidr_block" {
   default = "10.0.0.0/16"
   type    = string
@@ -53,4 +57,165 @@ variable "bastion_instance_type" {
 variable "bastion_ebs_optimized" {
   default = true
   type    = bool
+}
+
+variable "rds_allocated_storage" {
+  default = 32
+  type    = number
+}
+
+variable "rds_engine_version" {
+  default = 11
+  type    = number
+}
+
+variable "rds_parameter_group_family" {
+  default = "postgres11"
+  type    = string
+}
+
+variable "rds_instance_type" {
+  default = "db.t3.micro"
+  type    = string
+}
+
+variable "rds_storage_type" {
+  default = "gp2"
+  type    = string
+}
+
+variable "rds_database_identifier" {
+  type = string
+}
+
+variable "rds_database_name" {
+  type = string
+}
+
+variable "rds_database_username" {
+  type = string
+}
+
+variable "rds_database_password" {
+  type = string
+}
+
+variable "rds_backup_retention_period" {
+  default = 30
+  type    = number
+}
+
+variable "rds_backup_window" {
+  default = "04:00-04:30"
+  type    = string
+}
+
+variable "rds_maintenance_window" {
+  default = "sun:04:30-sun:05:30"
+  type    = string
+}
+
+variable "rds_auto_minor_version_upgrade" {
+  default = true
+  type    = bool
+}
+
+variable "rds_final_snapshot_identifier" {
+  default = "fieldscope-rds-snapshot"
+  type    = string
+}
+
+variable "rds_monitoring_interval" {
+  default = 60
+  type    = number
+}
+
+variable "rds_skip_final_snapshot" {
+  default = false
+  type    = bool
+}
+
+variable "rds_copy_tags_to_snapshot" {
+  default = true
+  type    = bool
+}
+
+variable "rds_multi_az" {
+  default = false
+  type    = bool
+}
+
+variable "rds_storage_encrypted" {
+  default = false
+  type    = bool
+}
+
+variable "rds_deletion_protection" {
+  default = true
+  type    = bool
+}
+
+variable "rds_seq_page_cost" {
+  default = 1
+  type    = number
+}
+
+variable "rds_random_page_cost" {
+  default = 1
+  type    = number
+}
+
+variable "rds_log_min_duration_statement" {
+  default = 500
+  type    = number
+}
+
+variable "rds_log_connections" {
+  default = 0
+  type    = number
+}
+
+variable "rds_log_disconnections" {
+  default = 0
+  type    = number
+}
+
+variable "rds_log_lock_waits" {
+  default = 1
+  type    = number
+}
+
+variable "rds_log_temp_files" {
+  default = 500
+  type    = number
+}
+
+variable "rds_log_autovacuum_min_duration" {
+  default = 250
+  type    = number
+}
+
+variable "rds_cpu_threshold_percent" {
+  default = 75
+  type    = number
+}
+
+variable "rds_disk_queue_threshold" {
+  default = 10
+  type    = number
+}
+
+variable "rds_free_disk_threshold_bytes" {
+  default = 5000000000
+  type    = number
+}
+
+variable "rds_free_memory_threshold_bytes" {
+  default = 128000000
+  type    = number
+}
+
+variable "rds_cpu_credit_balance_threshold" {
+  default = 30
+  type    = number
 }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,0 +1,14 @@
+variable "project" {
+  default = "Flood Mapping"
+  type    = string
+}
+
+variable "environment" {
+  default = "Staging"
+  type    = string
+}
+
+variable "aws_region" {
+  default = "us-east-1"
+  type    = string
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -65,12 +65,12 @@ variable "rds_allocated_storage" {
 }
 
 variable "rds_engine_version" {
-  default = 11
+  default = 12
   type    = number
 }
 
 variable "rds_parameter_group_family" {
-  default = "postgres11"
+  default = "postgres12"
   type    = string
 }
 

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "project" {
-  default = "Flood Mapping"
+  default = "Flood Map"
   type    = string
 }
 

--- a/deployment/terraform/versions.tf
+++ b/deployment/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12.13"
+}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,7 +1,7 @@
 version: "2.4"
 services:
   terraform:
-    image: quay.io/azavea/terraform:0.12.13
+    image: quay.io/azavea/terraform:0.12.29
     volumes:
       - ./:/usr/local/src
       - $HOME/.aws:/root/.aws:ro

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - AWS_PROFILE=${AWS_PROFILE:-noaa}
       - GIT_COMMIT=${GIT_COMMIT:-latest}
-      - NOAA_FLOOD_MAPPING_DEBUG=1
-      - NOAA_FLOOD_MAPPING_SETTINGS_BUCKET=${NOAA_FLOOD_MAPPING_SETTINGS_BUCKET:-floodmapping-staging-config-us-east-1}
+      - NOAA_FLOOD_MAP_DEBUG=1
+      - NOAA_FLOOD_MAP_SETTINGS_BUCKET=${NOAA_FLOOD_MAP_SETTINGS_BUCKET:-noaafloodmap-staging-config-us-east-1}
     working_dir: /usr/local/src
     entrypoint: bash

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,14 @@
+version: "2.4"
+services:
+  terraform:
+    image: quay.io/azavea/terraform:0.12.13
+    volumes:
+      - ./:/usr/local/src
+      - $HOME/.aws:/root/.aws:ro
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-noaa}
+      - GIT_COMMIT=${GIT_COMMIT:-latest}
+      - NOAA_FLOOD_MAPPING_DEBUG=1
+      - NOAA_FLOOD_MAPPING_SETTINGS_BUCKET=${NOAA_FLOOD_MAPPING_SETTINGS_BUCKET:-floodmapping-staging-config-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${NOAA_FLOOD_MAP_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0") COMMAND OPTION[S]
+Execute Terraform subcommands with remote state management.
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        TERRAFORM_DIR="$(dirname "$0")/../deployment/terraform"
+        echo
+        echo "Attempting to deploy application version [${GIT_COMMIT}]..."
+        echo "-----------------------------------------------------"
+        echo
+    fi
+
+    if [[ -n "${NOAA_FLOOD_MAP_SETTINGS_BUCKET}" ]]; then
+        pushd "${TERRAFORM_DIR}"
+
+        aws s3 cp "s3://${NOAA_FLOOD_MAP_SETTINGS_BUCKET}/terraform/terraform.tfvars" "${NOAA_FLOOD_MAP_SETTINGS_BUCKET}.tfvars"
+
+        case "${1}" in
+        plan)
+            # Clear stale modules & remote state, then re-initialize
+            rm -rf .terraform terraform.tfstate*
+            terraform init \
+                -backend-config="bucket=${NOAA_FLOOD_MAP_SETTINGS_BUCKET}" \
+                -backend-config="key=terraform/state"
+
+            terraform plan \
+                -var-file="${NOAA_FLOOD_MAP_SETTINGS_BUCKET}.tfvars" \
+                -out="${NOAA_FLOOD_MAP_SETTINGS_BUCKET}.tfplan"
+            ;;
+        apply)
+            terraform apply "${NOAA_FLOOD_MAP_SETTINGS_BUCKET}.tfplan"
+            ;;
+        *)
+            echo "ERROR: I don't have support for that Terraform subcommand!"
+            exit 1
+            ;;
+        esac
+
+        popd
+    else
+        echo "ERROR: No NOAA_FLOOD_MAP_SETTINGS_BUCKET variable defined."
+        exit 1
+    fi
+fi


### PR DESCRIPTION
## Overview

Configures a base VPC and RDS instance. Introduces the `infra` script.

Resolves #20 

## Testing Instructions

* Run this command to get a shell in the Terraform container and use the staging Terraform config bucket:
  ```#bash
  NOAA_FLOOD_MAP_SETTINGS_BUCKET=noaafloodmap-staging-config-us-east-1 docker-compose -f docker-compose.ci.yml run --rm terraform
  ```
* Run `./scripts/plan` and inspect the Terraform plan output. The command should run successfully but no changes should be necessary.
* SSH into the staging bastion host. The PEM is available in an NOAA Flood Map subdirectory on the fileshare.
* Confirm that you can connect to the RDS instance with `psql`. The password is available in the `terraform.tfvars` file.