### PR TITLE
Set up AWS Batch

### DIFF
--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -1,0 +1,175 @@
+#
+# Security Group resources
+#
+resource "aws_security_group" "batch" {
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sgBatchContainerInstance"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+#
+# Batch resources
+#
+# Pull the image IDs for the latest Amazon ECS optimized AMIs
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+data "aws_ssm_parameter" batch_cpu_container_instance_image_id {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+}
+
+data "aws_ssm_parameter" batch_gpu_container_instance_image_id {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id"
+}
+
+resource "aws_launch_template" "batch_cpu_container_instance" {
+  name_prefix = "ltBatchCPUContainerInstance-"
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      volume_size = var.batch_cpu_container_instance_volume_size
+      volume_type = "gp2"
+    }
+  }
+
+  user_data = filebase64("cloud-config/batch-container-instance.yml.tmpl")
+}
+
+resource "aws_launch_template" "batch_gpu_container_instance" {
+  name_prefix = "ltBatchGPUContainerInstance-"
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      volume_size = var.batch_gpu_container_instance_volume_size
+      volume_type = "gp2"
+    }
+  }
+}
+
+resource "aws_batch_compute_environment" "cpu" {
+  depends_on = [aws_iam_role_policy_attachment.batch_policy]
+
+  compute_environment_name_prefix = "batch${var.environment}CPUComputeEnvironment"
+  type                            = "MANAGED"
+  state                           = "ENABLED"
+  service_role                    = aws_iam_role.container_instance_batch.arn
+
+  compute_resources {
+    type                = "SPOT"
+    allocation_strategy = var.batch_cpu_ce_spot_fleet_allocation_strategy
+    bid_percentage      = var.batch_cpu_ce_spot_fleet_bid_precentage
+    ec2_key_pair        = var.aws_key_name
+    image_id            = data.aws_ssm_parameter.batch_cpu_container_instance_image_id.value
+
+    min_vcpus = var.batch_cpu_ce_min_vcpus
+    max_vcpus = var.batch_cpu_ce_max_vcpus
+
+    spot_iam_fleet_role = aws_iam_role.container_instance_spot_fleet.arn
+    instance_role       = aws_iam_instance_profile.container_instance.arn
+
+    instance_type = var.batch_cpu_ce_instance_types
+
+    launch_template {
+      launch_template_id = aws_launch_template.batch_cpu_container_instance.id
+      version            = aws_launch_template.batch_cpu_container_instance.latest_version
+    }
+
+    security_group_ids = [
+      aws_security_group.batch.id
+    ]
+
+    subnets = module.vpc.private_subnet_ids
+
+    tags = {
+      Name               = "BatchWorker"
+      ComputeEnvironment = "CPU"
+      Project            = var.project
+      Environment        = var.environment
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_batch_compute_environment" "gpu" {
+  depends_on = [aws_iam_role_policy_attachment.batch_policy]
+
+  compute_environment_name_prefix = "batch${var.environment}GPUComputeEnvironment"
+  type                            = "MANAGED"
+  state                           = "ENABLED"
+  service_role                    = aws_iam_role.container_instance_batch.arn
+
+  compute_resources {
+    type                = "SPOT"
+    allocation_strategy = var.batch_gpu_ce_spot_fleet_allocation_strategy
+    bid_percentage      = var.batch_gpu_ce_spot_fleet_bid_precentage
+    ec2_key_pair        = var.aws_key_name
+    image_id            = data.aws_ssm_parameter.batch_gpu_container_instance_image_id.value
+
+    min_vcpus = var.batch_gpu_ce_min_vcpus
+    max_vcpus = var.batch_gpu_ce_max_vcpus
+
+    spot_iam_fleet_role = aws_iam_role.container_instance_spot_fleet.arn
+    instance_role       = aws_iam_instance_profile.container_instance.arn
+
+    instance_type = var.batch_gpu_ce_instance_types
+
+    launch_template {
+      launch_template_id = aws_launch_template.batch_gpu_container_instance.id
+      version            = aws_launch_template.batch_gpu_container_instance.latest_version
+    }
+
+    security_group_ids = [
+      aws_security_group.batch.id
+    ]
+
+    subnets = module.vpc.private_subnet_ids
+
+    tags = {
+      Name               = "BatchWorker"
+      ComputeEnvironment = "GPU"
+      Project            = var.project
+      Environment        = var.environment
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_batch_job_queue" "cpu" {
+  name                 = "queue${var.environment}CPU"
+  priority             = 1
+  state                = "ENABLED"
+  compute_environments = [aws_batch_compute_environment.cpu.arn]
+}
+
+resource "aws_batch_job_queue" "gpu" {
+  name                 = "queue${var.environment}GPU"
+  priority             = 1
+  state                = "ENABLED"
+  compute_environments = [aws_batch_compute_environment.gpu.arn]
+}
+
+resource "aws_batch_job_definition" "test_cpu" {
+  name = "job${var.environment}TestCPU"
+  type = "container"
+
+  container_properties = templatefile("job-definitions/test-cpu.json.tmpl", {})
+}
+
+resource "aws_batch_job_definition" "test_gpu" {
+  name = "job${var.environment}TestGPU"
+  type = "container"
+
+  container_properties = templatefile("job-definitions/test-gpu.json.tmpl", {})
+}

--- a/deployment/terraform/cloud-config/batch-container-instance.yml.tmpl
+++ b/deployment/terraform/cloud-config/batch-container-instance.yml.tmpl
@@ -1,0 +1,18 @@
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-boothook; charset="us-ascii"
+
+# Manually mount unformatted instance store volumes. Mounting in a cloud-boothook
+# makes it more likely the drive is mounted before the Docker daemon and ECS agent
+# start, which helps mitigate potential race conditions.
+#
+# See:
+# - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon
+# - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html#supported-user-data-formats
+mkfs.ext4 -E nodiscard /dev/nvme1n1
+mkdir -p /media/ephemeral0
+mount -t ext4 -o defaults,nofail,discard /dev/nvme1n1 /media/ephemeral0
+
+--==BOUNDARY==

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -11,6 +11,16 @@ resource "aws_security_group_rule" "bastion_ssh_ingress" {
   security_group_id = module.vpc.bastion_security_group_id
 }
 
+resource "aws_security_group_rule" "bastion_ssh_egress" {
+  type      = "egress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  security_group_id        = module.vpc.bastion_security_group_id
+  source_security_group_id = aws_security_group.batch.id
+}
+
 resource "aws_security_group_rule" "bastion_rds_egress" {
   type      = "egress"
   from_port = module.database.port
@@ -32,4 +42,47 @@ resource "aws_security_group_rule" "rds_bastion_ingress" {
 
   security_group_id        = module.database.database_security_group_id
   source_security_group_id = module.vpc.bastion_security_group_id
+}
+
+resource "aws_security_group_rule" "rds_container_instance_ingress" {
+  type      = "ingress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = module.database.database_security_group_id
+  source_security_group_id = aws_security_group.batch.id
+}
+
+#
+# Container instance security group resources
+#
+resource "aws_security_group_rule" "container_instance_ssh_ingress" {
+  type      = "ingress"
+  from_port = 22
+  to_port   = 22
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.batch.id
+  source_security_group_id = module.vpc.bastion_security_group_id
+}
+
+resource "aws_security_group_rule" "container_instance_https_egress" {
+  type        = "egress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.batch.id
+}
+
+resource "aws_security_group_rule" "container_instance_rds_egress" {
+  type      = "egress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.batch.id
+  source_security_group_id = module.database.database_security_group_id
 }

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -1,0 +1,82 @@
+#
+# Container Instance IAM resources
+#
+data "aws_iam_policy_document" "container_instance_ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "container_instance_ec2" {
+  name               = "${var.environment}ContainerInstanceProfile"
+  assume_role_policy = data.aws_iam_policy_document.container_instance_ec2_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_service_role" {
+  role       = aws_iam_role.container_instance_ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_instance_profile" "container_instance" {
+  name = aws_iam_role.container_instance_ec2.name
+  role = aws_iam_role.container_instance_ec2.name
+}
+
+#
+# Spot Fleet IAM resources
+#
+data "aws_iam_policy_document" "container_instance_spot_fleet_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["spotfleet.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "container_instance_spot_fleet" {
+  name               = "fleet${var.environment}ServiceRole"
+  assume_role_policy = data.aws_iam_policy_document.container_instance_spot_fleet_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "spot_fleet_policy" {
+  role       = aws_iam_role.container_instance_spot_fleet.name
+  policy_arn = var.aws_spot_fleet_service_role_policy_arn
+}
+
+#
+# Batch IAM resources
+#
+data "aws_iam_policy_document" "container_instance_batch_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["batch.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "container_instance_batch" {
+  name               = "batch${var.environment}ServiceRole"
+  assume_role_policy = data.aws_iam_policy_document.container_instance_batch_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "batch_policy" {
+  role       = aws_iam_role.container_instance_batch.name
+  policy_arn = var.aws_batch_service_role_policy_arn
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -21,12 +21,36 @@ resource "aws_iam_role" "container_instance_ec2" {
 
 resource "aws_iam_role_policy_attachment" "ec2_service_role" {
   role       = aws_iam_role.container_instance_ec2.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  policy_arn = var.aws_ec2_service_role_policy_arn
 }
 
 resource "aws_iam_instance_profile" "container_instance" {
   name = aws_iam_role.container_instance_ec2.name
   role = aws_iam_role.container_instance_ec2.name
+}
+
+data "aws_iam_policy_document" "scoped_data" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:DeleteObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.data.arn}",
+      "${aws_s3_bucket.data.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "scoped_data" {
+  name   = "s3${var.environment}ScopedDataPolicy"
+  role   = aws_iam_role.container_instance_ec2.name
+  policy = data.aws_iam_policy_document.scoped_data.json
 }
 
 #

--- a/deployment/terraform/job-definitions/test-cpu.json.tmpl
+++ b/deployment/terraform/job-definitions/test-cpu.json.tmpl
@@ -1,0 +1,28 @@
+{
+    "image": "amazonlinux:latest",
+    "vcpus": 2,
+    "memory": 2048,
+    "command": [
+        "df",
+        "-h"
+    ],
+    "volumes": [
+        {
+            "host": {
+                "sourcePath": "/media/ephemeral0"
+            },
+            "name": "ephemeral0"
+        }
+    ],
+    "environment": [],
+    "mountPoints": [
+        {
+            "containerPath": "/tmp",
+            "readOnly": false,
+            "sourceVolume": "ephemeral0"
+        }
+    ],
+    "privileged": false,
+    "ulimits": [],
+    "resourceRequirements": []
+}

--- a/deployment/terraform/job-definitions/test-gpu.json.tmpl
+++ b/deployment/terraform/job-definitions/test-gpu.json.tmpl
@@ -1,0 +1,21 @@
+{
+    "image": "nvidia/cuda:9.0-base",
+    "vcpus": 2,
+    "memory": 2048,
+    "command": [
+        "sh",
+        "-c",
+        "nvidia-smi"
+    ],
+    "volumes": [],
+    "environment": [],
+    "mountPoints": [],
+    "privileged": false,
+    "ulimits": [],
+    "resourceRequirements": [
+        {
+            "type": "GPU",
+            "value": "1"
+        }
+    ]
+}

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,0 +1,10 @@
+resource "aws_s3_bucket" "data" {
+  bucket = "noaafloodmap-${lower(var.environment)}-data-${var.aws_region}"
+  acl    = "private"
+
+  tags = {
+    Name        = "noaafloodmap-${lower(var.environment)}-data-${var.aws_region}"
+    Project     = var.project
+    Environment = var.environment
+  }
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -219,3 +219,63 @@ variable "rds_cpu_credit_balance_threshold" {
   default = 30
   type    = number
 }
+
+variable "batch_cpu_container_instance_volume_size" {
+  type    = number
+  default = 30
+}
+
+variable "batch_gpu_container_instance_volume_size" {
+  type    = number
+  default = 30
+}
+
+variable "batch_cpu_ce_min_vcpus" {
+  type = number
+}
+
+variable "batch_gpu_ce_min_vcpus" {
+  type = number
+}
+
+variable "batch_cpu_ce_max_vcpus" {
+  type = number
+}
+
+variable "batch_gpu_ce_max_vcpus" {
+  type = number
+}
+
+variable "batch_cpu_ce_instance_types" {
+  type = list(string)
+}
+
+variable "batch_gpu_ce_instance_types" {
+  type = list(string)
+}
+
+variable "batch_cpu_ce_spot_fleet_allocation_strategy" {
+  type = string
+}
+
+variable "batch_gpu_ce_spot_fleet_allocation_strategy" {
+  type = string
+}
+
+variable "batch_cpu_ce_spot_fleet_bid_precentage" {
+  type = number
+}
+
+variable "batch_gpu_ce_spot_fleet_bid_precentage" {
+  type = number
+}
+
+variable "aws_spot_fleet_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+  type    = string
+}
+
+variable "aws_batch_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+  type    = string
+}

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -227,7 +227,7 @@ variable "batch_cpu_container_instance_volume_size" {
 
 variable "batch_gpu_container_instance_volume_size" {
   type    = number
-  default = 30
+  default = 128
 }
 
 variable "batch_cpu_ce_min_vcpus" {
@@ -277,5 +277,10 @@ variable "aws_spot_fleet_service_role_policy_arn" {
 
 variable "aws_batch_service_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+  type    = string
+}
+
+variable "aws_ec2_service_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
   type    = string
 }


### PR DESCRIPTION
## Overview

- Add CPU and GPU-based Batch compute environments, job queues, and example job definitions
- Add IAM resources for Batch container instances and Spot Fleet

Resolves #25 

## Testing Instructions

- Select **AWS Batch** → **Jobs** → **Submit job**
- Select the following
  - **Job name**: `Joker`
  - **Job definition**: `jobStagingTestCPU:1`
  - **Job queue**: `queueStagingCPU`
- Click **Submit job**
- Select the job and click **View logs** after it succeeds
- Verify that ephemeral storage was mounted and is [appropriate](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#instance-store-volumes) for `c5d.xlarge`:
```bash
------------------------------------------------------------------------
|   timestamp   |                       message                        |
|---------------|------------------------------------------------------|
| 1596475604730 | Filesystem      Size  Used Avail Use% Mounted on     |
| 1596475604730 | overlay          30G  1.4G   28G   5% /              |
| 1596475604730 | tmpfs            64M     0   64M   0% /dev           |
| 1596475604730 | tmpfs           3.8G     0  3.8G   0% /sys/fs/cgroup |
| 1596475604730 | /dev/nvme1n1     92G   61M   87G   1% /tmp           |
| 1596475604730 | /dev/nvme0n1p1   30G  1.4G   28G   5% /etc/hosts     |
| 1596475604730 | shm              64M     0   64M   0% /dev/shm       |
| 1596475604730 | tmpfs           3.8G     0  3.8G   0% /proc/acpi     |
| 1596475604730 | tmpfs           3.8G     0  3.8G   0% /sys/firmware  |
------------------------------------------------------------------------
```

- Select **AWS Batch** → **Jobs** → **Submit job**
- Select the following
  - **Job name**: `Joker`
  - **Job definition**: `jobStagingTestGPU:1`
  - **Job queue**: `queueStagingGPU`
- Click **Submit job**
- Select the job and click **View logs** after it succeeds
- Verify the GPU is accessible to the container runtime:
```bash
---------------------------------------------------------------------------------------------------
|   timestamp   |                                     message                                     |
|---------------|---------------------------------------------------------------------------------|
| 1596478793840 | Mon Aug  3 18:19:53 2020                                                        |
| 1596478793840 | +-----------------------------------------------------------------------------+ |
| 1596478793840 | | NVIDIA-SMI 418.87.00    Driver Version: 418.87.00    CUDA Version: 10.1     | |
| 1596478793840 | |-------------------------------+----------------------+----------------------+ |
| 1596478793840 | | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC | |
| 1596478793840 | | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. | |
| 1596478793840 | |===============================+======================+======================| |
| 1596478793847 | |   0  Tesla V100-SXM2...  On   | 00000000:00:1E.0 Off |                    0 | |
| 1596478793847 | | N/A   36C    P0    25W / 300W |      0MiB / 16130MiB |      0%      Default | |
| 1596478793847 | +-------------------------------+----------------------+----------------------+ |
| 1596478793847 |                                                                                 |
| 1596478793847 | +-----------------------------------------------------------------------------+ |
| 1596478793847 | | Processes:                                                       GPU Memory | |
| 1596478793847 | |  GPU       PID   Type   Process name                             Usage      | |
| 1596478793847 | |=============================================================================| |
| 1596478793847 | |  No running processes found                                                 | |
| 1596478793847 | +-----------------------------------------------------------------------------+ |
---------------------------------------------------------------------------------------------------
```

