### PR TITLE
Upgrade Terraform AWS provider to 3.x

### DIFF
--- a/deployment/terraform/config.tf
+++ b/deployment/terraform/config.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = var.aws_region
-  version = "~> 2.70.0"
+  version = "~> 3.0.0"
 }
 
 terraform {

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,5 +1,5 @@
 module "vpc" {
-  source = "github.com/azavea/terraform-aws-vpc?ref=6.0.0"
+  source = "github.com/azavea/terraform-aws-vpc?ref=6.0.1"
 
   name                       = "vpc${replace(var.project, " ", "")}${var.environment}"
   region                     = var.aws_region


### PR DESCRIPTION
Upgrade the Terraform AWS provider to version 3.x. Also, update to a version of the VPC module that removes deprecated use of quoted resource references.

---

**Testing**

- Within the context of the Terraform container image associated with this project:

```console
bash-5.0# ./scripts/infra plan
bash-5.0# ./scripts/infra apply
```

- Ensure that no changes are reported and no deprecation warnings are emitted

(Warnings may surface due to references to undeclared variables, but those variables are related to ongoing work to complete https://github.com/azavea/noaa-flood-mapping/issues/15.)

