### PR TITLE
Build Raster Vision config from STAC

### DIFF
--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/azavea/raster-vision:pytorch-v0.12.0
+
+RUN pip3 install --upgrade pystac==0.4.0
+
+CMD ["bash"]

--- a/inference/README.md
+++ b/inference/README.md
@@ -2,11 +2,12 @@
 
 Build the docker container, which upgrades pystac to 0.4.0 for compatibility with the catalogs generated in [catalogs](../catalogs).
 
-````bash
+```bash
 docker build . --tag raster-vision:pytorch-pystac-v0.4.0
 ```
 
 Start the container ensuring:
+
 1. that environment variables are appropriately set to generate Raster Vision configuration.
 2. that volume mounts are set such that `rv_stac_config.py` and the machine learning STAC is accessible from within the container. Make sure that the `CATALOG_ROOT_URI` variable points to the machine learning STAC root mounted within the container.
 3. that if documents are referred to using S3 URIs within the ML STAC, `~/.aws` is mounted to `/root/.aws` so that credentials are accessible within the container (if this is the case, be sure to run `aws configure` from within the container prior to running your Raster Vision job)
@@ -19,7 +20,7 @@ docker run --rm -it \
   -v ${RV_CODE_DIR}:/opt/src/code \
   -v ${RV_OUT_DIR}:/opt/data/output \
   raster-vision:pytorch-pystac-v0.4.0 /bin/bash
-````
+```
 
 Within the container, run the Raster Vision process locally, pointing the process to `rv_stac_config.py`. (Remember to run `aws configure` for credentials if necessary!)
 

--- a/inference/README.md
+++ b/inference/README.md
@@ -1,0 +1,28 @@
+# Training a Torch Model Locally
+
+Build the docker container, which upgrades pystac to 0.4.0 for compatibility with the catalogs generated in [catalogs](../catalogs).
+
+````bash
+docker build . --tag raster-vision:pytorch-pystac-v0.4.0
+```
+
+Start the container ensuring:
+1. that environment variables are appropriately set to generate Raster Vision configuration.
+2. that volume mounts are set such that `rv_stac_config.py` and the machine learning STAC is accessible from within the container. Make sure that the `CATALOG_ROOT_URI` variable points to the machine learning STAC root mounted within the container.
+3. that if documents are referred to using S3 URIs within the ML STAC, `~/.aws` is mounted to `/root/.aws` so that credentials are accessible within the container (if this is the case, be sure to run `aws configure` from within the container prior to running your Raster Vision job)
+
+```bash
+docker run --rm -it \
+  -e OUTPUT_ROOT_URI=/opt/data/output \
+  -e CATALOG_ROOT_URI=/opt/src/code/ml_stac/catalog.json \
+  -v ~/.aws:/root/.aws \
+  -v ${RV_CODE_DIR}:/opt/src/code \
+  -v ${RV_OUT_DIR}:/opt/data/output \
+  raster-vision:pytorch-pystac-v0.4.0 /bin/bash
+````
+
+Within the container, run the Raster Vision process locally, pointing the process to `rv_stac_config.py`. (Remember to run `aws configure` for credentials if necessary!)
+
+```bash
+rastervision run local /opt/src/code/rv_stac_config.py
+```

--- a/inference/rv_stac_config.py
+++ b/inference/rv_stac_config.py
@@ -1,0 +1,145 @@
+# flake8: noqa
+
+import os
+from os.path import join
+
+from rastervision.core.rv_pipeline import *
+from rastervision.core.backend import *
+from rastervision.core.data import *
+from rastervision.pytorch_backend import *
+from rastervision.pytorch_learner import *
+from rastervision.gdal_vsi.vsi_file_system import VsiFileSystem
+
+from pystac import Catalog, Collection, Item
+from rastervision.core.data import (
+    ClassConfig,
+    RasterioSourceConfig,
+    StatsTransformerConfig,
+    SemanticSegmentationLabelSourceConfig,
+    RasterizedSourceConfig,
+    GeoJSONVectorSourceConfig,
+    RasterizerConfig,
+    SceneConfig,
+    DatasetConfig,
+)
+from typing import Generator
+
+
+def image_sources(item: Item, channel_order: [int]):
+    image_keys = [key for key in item.assets.keys() if key.startswith("image")]
+    image_keys.sort()
+    image_uris = [
+        VsiFileSystem.uri_to_vsi_path(item.assets[key].href) for key in image_keys
+    ]
+    return RasterioSourceConfig(uris=image_uris, channel_order=channel_order,)
+
+
+def make_scenes_from_item(item: Item, channel_order: [int]) -> [SceneConfig]:
+    # get all links to labels
+    label_items = [
+        link.resolve_stac_object().target for link in item.links if link.rel == "labels"
+    ]
+
+    scene_configs = []
+    # iterate through links, building a scene config per link
+    for label_item in label_items:
+        label_asset = label_item.assets["labels"]
+        label_uri = label_asset.href
+
+        # rasterio source configs
+        image_source = image_sources(item, channel_order)
+
+        # semantic segmentation label configuration; convert to tif as necesary
+        if label_asset.media_type == "image/tiff; application=geotiff":
+            raster_label_source = RasterioSourceConfig(uris=[label_asset.href],)
+        else:
+            vector_label_source = GeoJSONVectorSourceConfig(
+                uri=label_uri, default_class_id=0, ignore_crs_field=True
+            )
+            raster_label_source = RasterizedSourceConfig(
+                vector_source=vector_source,
+                rasterizer_config=RasterizerConfig(background_class_id=1),
+            )
+
+        label_source = SemanticSegmentationLabelSourceConfig(
+            raster_source=raster_label_source
+        )
+
+        scene_configs.append(
+            SceneConfig(
+                id=item.id, raster_source=image_source, label_source=label_source
+            )
+        )
+    return scene_configs
+
+
+def make_scenes(collection: Collection, channel_order: [int]):
+    scene_groups = [
+        make_scenes_from_item(item, channel_order) for item in collection.get_items()
+    ]
+    scenes = []
+    for group in scene_groups:
+        for scene in group:
+            scenes.append(scene)
+    return scenes
+
+
+def build_dataset_from_catalog(
+    catalog: Catalog, channel_order: [int], class_config: ClassConfig
+) -> DatasetConfig:
+
+    # Read taining scenes from STAC
+    train_collection = catalog.get_child(id="train")
+    train_scenes = make_scenes(train_collection, channel_order)
+
+    # Read testing scenes from STAC
+    test_collection = catalog.get_child(id="test")
+    test_scenes = make_scenes(test_collection, channel_order)
+
+    return DatasetConfig(
+        class_config=class_config,
+        train_scenes=train_scenes,
+        validation_scenes=test_scenes,
+    )
+
+
+def get_config(runner):
+    output_root_uri = os.environ.get("OUTPUT_ROOT_URI")
+    if output_root_uri is None:
+        sys.exit("No output URI set. Set the environment variable OUTPUT_ROOT_URI")
+
+    catalog_root = os.environ.get("CATALOG_ROOT_URI")
+    if catalog_root is None:
+        sys.exit("No catalog URI set. Set the environment variable CATALOG_ROOT_URI")
+
+    # Read STAC catalog
+    catalog: Catalog = Catalog.from_file(catalog_root)
+
+    # TODO: pull desired channels from root collection properties
+    channel_ordering: [int] = [0, 1, 2]
+
+    # TODO: pull ClassConfig info from root collection properties
+    class_config: ClassConfig = ClassConfig(
+        names=["not water", "water"], colors=["white", "blue"]
+    )
+
+    dataset = build_dataset_from_catalog(catalog, channel_ordering, class_config)
+
+    chip_sz = 300
+    backend = PyTorchSemanticSegmentationConfig(
+        model=SemanticSegmentationModelConfig(backbone=Backbone.resnet50),
+        solver=SolverConfig(lr=1e-4, num_epochs=1, batch_sz=2),
+    )
+    chip_options = SemanticSegmentationChipOptions(
+        window_method=SemanticSegmentationWindowMethod.random_sample, chips_per_scene=10
+    )
+
+    return SemanticSegmentationConfig(
+        root_uri=output_root_uri,
+        dataset=dataset,
+        backend=backend,
+        train_chip_sz=chip_sz,
+        predict_chip_sz=chip_sz,
+        chip_options=chip_options,
+    )
+

--- a/inference/rv_stac_config.py
+++ b/inference/rv_stac_config.py
@@ -10,7 +10,7 @@ from rastervision.pytorch_backend import *
 from rastervision.pytorch_learner import *
 from rastervision.gdal_vsi.vsi_file_system import VsiFileSystem
 
-from pystac import Catalog, Collection, Item
+from pystac import Catalog, Collection, Item, MediaType
 from rastervision.core.data import (
     ClassConfig,
     RasterioSourceConfig,
@@ -40,17 +40,18 @@ def make_scenes_from_item(item: Item, channel_order: [int]) -> [SceneConfig]:
         link.resolve_stac_object().target for link in item.links if link.rel == "labels"
     ]
 
+    # image source configs
+    image_source = image_sources(item, channel_order)
+
     scene_configs = []
     # iterate through links, building a scene config per link
     for label_item in label_items:
         label_asset = label_item.assets["labels"]
         label_uri = label_asset.href
 
-        # rasterio source configs
-        image_source = image_sources(item, channel_order)
 
         # semantic segmentation label configuration; convert to tif as necesary
-        if label_asset.media_type == "image/tiff; application=geotiff":
+        if label_asset.media_type == MediaType.GEOTIFF
             raster_label_source = RasterioSourceConfig(uris=[label_asset.href],)
         else:
             vector_label_source = GeoJSONVectorSourceConfig(

--- a/inference/rv_stac_config.py
+++ b/inference/rv_stac_config.py
@@ -31,7 +31,11 @@ def image_sources(item: Item, channel_order: [int]):
     image_uris = [
         VsiFileSystem.uri_to_vsi_path(item.assets[key].href) for key in image_keys
     ]
-    return RasterioSourceConfig(uris=image_uris, channel_order=channel_order,)
+    return RasterioSourceConfig(
+        uris=image_uris,
+        channel_order=channel_order,
+        transformers=[StatsTransformerConfig()],
+    )
 
 
 def make_scenes_from_item(item: Item, channel_order: [int]) -> [SceneConfig]:
@@ -49,9 +53,8 @@ def make_scenes_from_item(item: Item, channel_order: [int]) -> [SceneConfig]:
         label_asset = label_item.assets["labels"]
         label_uri = label_asset.href
 
-
         # semantic segmentation label configuration; convert to tif as necesary
-        if label_asset.media_type == MediaType.GEOTIFF
+        if label_asset.media_type == MediaType.GEOTIFF:
             raster_label_source = RasterioSourceConfig(uris=[label_asset.href],)
         else:
             vector_label_source = GeoJSONVectorSourceConfig(


### PR DESCRIPTION
# Overview

This PR complements #40 by implementing the generation of Raster Vision job configurations on the basis of the `mldata` STAC schemas laid out therein.

TODO:
- [x] fix prediction step/'recipe for target 3' (`TypeError: can't convert np.ndarray of type numpy.uint16. The only supported types are: float64, float32, float16, int64, int32, int16, int8, uint8, and bool.`)

# Testing

There are some issues with the STACs as currently generated by #40. As such a STAC which includes only labels that comply with the expectations of torch (and which is mercifully small so that a job can quickly be run) is found here: 
[mldata_s2weak_test.tar.gz](https://github.com/azavea/noaa-flood-mapping/files/5030501/mldata_s2weak_test.tar.gz)


Closes #44

