### PR TITLE
Set up Franklin

### DIFF
--- a/deployment/terraform/certificate.tf
+++ b/deployment/terraform/certificate.tf
@@ -1,0 +1,16 @@
+#
+# ACM resources
+#
+module "cert" {
+  source = "github.com/azavea/terraform-aws-acm-certificate?ref=develop"
+
+  providers = {
+    aws.acm_account     = aws
+    aws.route53_account = aws
+  }
+
+  domain_name               = var.r53_public_hosted_zone
+  subject_alternative_names = ["*.${var.r53_public_hosted_zone}"]
+  hosted_zone_id            = aws_route53_zone.external.zone_id
+  validation_record_ttl     = 60
+}

--- a/deployment/terraform/certificate.tf
+++ b/deployment/terraform/certificate.tf
@@ -2,7 +2,7 @@
 # ACM resources
 #
 module "cert" {
-  source = "github.com/azavea/terraform-aws-acm-certificate?ref=develop"
+  source = "github.com/azavea/terraform-aws-acm-certificate?ref=3.0.0"
 
   providers = {
     aws.acm_account     = aws

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -22,3 +22,34 @@ resource "aws_route53_record" "database" {
   ttl     = "10"
   records = [module.database.hostname]
 }
+
+#
+# Public DNS resources
+#
+resource "aws_route53_zone" "external" {
+  name = var.r53_public_hosted_zone
+}
+
+resource "aws_route53_record" "franklin" {
+  zone_id = aws_route53_zone.external.zone_id
+  name    = "franklin.${var.r53_public_hosted_zone}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.franklin.dns_name
+    zone_id                = aws_lb.franklin.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "franklin_ipv6" {
+  zone_id = aws_route53_zone.external.zone_id
+  name    = "franklin.${var.r53_public_hosted_zone}"
+  type    = "AAAA"
+
+  alias {
+    name                   = aws_lb.franklin.dns_name
+    zone_id                = aws_lb.franklin.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/deployment/terraform/firewall.tf
+++ b/deployment/terraform/firewall.tf
@@ -54,6 +54,17 @@ resource "aws_security_group_rule" "rds_container_instance_ingress" {
   source_security_group_id = aws_security_group.batch.id
 }
 
+resource "aws_security_group_rule" "rds_franklin_ingress" {
+  type      = "ingress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = module.database.database_security_group_id
+  source_security_group_id = aws_security_group.franklin.id
+}
+
+
 #
 # Container instance security group resources
 #
@@ -84,5 +95,74 @@ resource "aws_security_group_rule" "container_instance_rds_egress" {
   protocol  = "tcp"
 
   security_group_id        = aws_security_group.batch.id
+  source_security_group_id = module.database.database_security_group_id
+}
+
+#
+# Franklin ALB security group resources
+#
+resource "aws_security_group_rule" "alb_http_ingress" {
+  type             = "ingress"
+  from_port        = 80
+  to_port          = 80
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "alb_https_ingress" {
+  type             = "ingress"
+  from_port        = 443
+  to_port          = 443
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "alb_franklin_egress" {
+  type      = "egress"
+  from_port = 9090
+  to_port   = 9090
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.alb.id
+  source_security_group_id = aws_security_group.franklin.id
+}
+
+#
+# Franklin container instance security group resources
+#
+resource "aws_security_group_rule" "franklin_https_egress" {
+  type             = "egress"
+  from_port        = 443
+  to_port          = 443
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+
+  security_group_id = aws_security_group.franklin.id
+}
+
+resource "aws_security_group_rule" "franklin_alb_ingress" {
+  type      = "ingress"
+  from_port = 9090
+  to_port   = 9090
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.franklin.id
+  source_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "franklin_rds_egress" {
+  type      = "egress"
+  from_port = module.database.port
+  to_port   = module.database.port
+  protocol  = "tcp"
+
+  security_group_id        = aws_security_group.franklin.id
   source_security_group_id = module.database.database_security_group_id
 }

--- a/deployment/terraform/franklin.tf
+++ b/deployment/terraform/franklin.tf
@@ -1,0 +1,200 @@
+#
+# Security Group Resources
+#
+resource "aws_security_group" "alb" {
+  name   = "sg${var.environment}FranklinLoadBalancer"
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sg${var.environment}FranklinLoadBalancer",
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_security_group" "franklin" {
+  name   = "sg${var.environment}FranklinEcsService"
+  vpc_id = module.vpc.id
+
+  tags = {
+    Name        = "sg${var.environment}FranklinEcsService",
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+#
+# ALB Resources
+#
+resource "aws_lb" "franklin" {
+  name            = "alb${var.environment}Franklin"
+  security_groups = [aws_security_group.alb.id]
+  subnets         = module.vpc.public_subnet_ids
+
+  enable_http2 = true
+
+  tags = {
+    Name        = "alb${var.environment}Franklin"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_lb_target_group" "franklin" {
+  name = "tg${var.environment}Franklin"
+
+  health_check {
+    healthy_threshold   = 3
+    interval            = 30
+    matcher             = 200
+    protocol            = "HTTP"
+    timeout             = 3
+    path                = "/open-api/spec.yaml"
+    unhealthy_threshold = 2
+  }
+
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = module.vpc.id
+
+  target_type = "ip"
+
+  tags = {
+    Name        = "tg${var.environment}Franklin"
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_lb_listener" "franklin_redirect" {
+  load_balancer_arn = aws_lb.franklin.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = 443
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "franklin" {
+  load_balancer_arn = aws_lb.franklin.id
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = module.cert.arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.franklin.id
+    type             = "forward"
+  }
+}
+
+#
+# ECS Resources
+#
+resource "aws_ecs_cluster" "franklin" {
+  name = "ecs${var.environment}Cluster"
+}
+
+resource "aws_ecs_task_definition" "franklin" {
+  family                   = "${var.environment}Franklin"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.franklin_cpu
+  memory                   = var.franklin_memory
+
+  task_role_arn      = aws_iam_role.ecs_task_role.arn
+  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = templatefile("${path.module}/task-definitions/franklin.json.tmpl", {
+    image = "quay.io/azavea/franklin:${var.franklin_image_tag}"
+
+    postgres_user     = var.rds_database_username
+    postgres_password = var.rds_database_password
+    postgres_host     = aws_route53_record.database.fqdn
+    postgres_name     = "franklin"
+    api_host          = aws_route53_record.franklin.name
+
+    environment = var.environment
+    aws_region  = var.aws_region
+  })
+
+  tags = {
+    Name        = "${var.environment}Franklin",
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_ecs_task_definition" "franklin_migrations" {
+  family                   = "${var.environment}FranklinMigrations"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.franklin_migrations_cpu
+  memory                   = var.franklin_migrations_memory
+
+  task_role_arn      = aws_iam_role.ecs_task_role.arn
+  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
+
+  container_definitions = templatefile("${path.module}/task-definitions/franklin_migrations.json.tmpl", {
+    image = "quay.io/azavea/franklin:${var.franklin_image_tag}"
+
+    postgres_user     = var.rds_database_username
+    postgres_password = var.rds_database_password
+    postgres_host     = aws_route53_record.database.fqdn
+    postgres_name     = "franklin"
+
+    environment = var.environment
+    aws_region  = var.aws_region
+  })
+
+  tags = {
+    Name        = "${var.environment}FranklinMigrations",
+    Project     = var.project
+    Environment = var.environment
+  }
+}
+
+resource "aws_ecs_service" "franklin" {
+  name            = "${var.environment}Franklin"
+  cluster         = aws_ecs_cluster.franklin.name
+  task_definition = aws_ecs_task_definition.franklin.arn
+
+  desired_count                      = var.franklin_desired_count
+  deployment_minimum_healthy_percent = var.franklin_deployment_min_percent
+  deployment_maximum_percent         = var.franklin_deployment_max_percent
+
+  launch_type = "FARGATE"
+
+  network_configuration {
+    security_groups = [aws_security_group.franklin.id]
+    subnets         = module.vpc.private_subnet_ids
+  }
+
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.franklin.arn
+    container_name   = "franklin"
+    container_port   = 9090
+  }
+
+  depends_on = [aws_lb_listener.franklin]
+}
+
+#
+# CloudWatch Resources
+#
+resource "aws_cloudwatch_log_group" "franklin" {
+  name              = "log${var.environment}Franklin"
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_group" "franklin_migrations" {
+  name              = "log${var.environment}FranklinMigrations"
+  retention_in_days = 30
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -104,3 +104,36 @@ resource "aws_iam_role_policy_attachment" "batch_policy" {
   role       = aws_iam_role.container_instance_batch.name
   policy_arn = var.aws_batch_service_role_policy_arn
 }
+
+#
+# ECS IAM resources
+#
+data "aws_iam_policy_document" "ecs_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+  }
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "ecs${var.environment}TaskExecutionRole"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "ecs${var.environment}TaskRole"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = var.aws_ecs_task_execution_role_policy_arn
+}

--- a/deployment/terraform/task-definitions/franklin.json.tmpl
+++ b/deployment/terraform/task-definitions/franklin.json.tmpl
@@ -1,0 +1,42 @@
+[
+  {
+    "cpu": 0,
+    "essential": true,
+    "image": "${image}",
+    "name": "franklin",
+    "portMappings": [
+      {
+        "containerPort": 9090
+      }
+    ],
+    "command": [
+      "serve",
+      "--db-user",
+      "${postgres_user}",
+      "--db-password",
+      "${postgres_password}",
+      "--db-host",
+      "${postgres_host}",
+      "--db-port",
+      "5432",
+      "--db-name",
+      "${postgres_name}",
+      "--api-host",
+      "${api_host}",
+      "--api-scheme",
+      "https",
+      "--external-port",
+      "443",
+      "--with-transactions",
+      "--with-tiles"
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "log${environment}Franklin",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "franklin"
+      }
+    }
+  }
+]

--- a/deployment/terraform/task-definitions/franklin_migrations.json.tmpl
+++ b/deployment/terraform/task-definitions/franklin_migrations.json.tmpl
@@ -1,0 +1,29 @@
+[
+  {
+    "cpu": 0,
+    "essential": true,
+    "image": "${image}",
+    "name": "franklin-migrations",
+    "command": [
+      "migrate",
+      "--db-user",
+      "${postgres_user}",
+      "--db-password",
+      "${postgres_password}",
+      "--db-host",
+      "${postgres_host}",
+      "--db-port",
+      "5432",
+      "--db-name",
+      "${postgres_name}"
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "log${environment}FranklinMigrations",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "franklin-migrations"
+      }
+    }
+  }
+]

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -26,6 +26,10 @@ variable "r53_private_hosted_zone" {
   type = string
 }
 
+variable "r53_public_hosted_zone" {
+  type = string
+}
+
 variable "vpc_cidr_block" {
   default = "10.0.0.0/16"
   type    = string
@@ -270,6 +274,38 @@ variable "batch_gpu_ce_spot_fleet_bid_precentage" {
   type = number
 }
 
+variable "franklin_desired_count" {
+  type = number
+}
+
+variable "franklin_deployment_min_percent" {
+  type = number
+}
+
+variable "franklin_deployment_max_percent" {
+  type = number
+}
+
+variable "franklin_image_tag" {
+  type = string
+}
+
+variable "franklin_cpu" {
+  type = number
+}
+
+variable "franklin_memory" {
+  type = number
+}
+
+variable "franklin_migrations_cpu" {
+  type = number
+}
+
+variable "franklin_migrations_memory" {
+  type = number
+}
+
 variable "aws_spot_fleet_service_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
   type    = string
@@ -282,5 +318,10 @@ variable "aws_batch_service_role_policy_arn" {
 
 variable "aws_ec2_service_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  type    = string
+}
+
+variable "aws_ecs_task_execution_role_policy_arn" {
+  default = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
   type    = string
 }


### PR DESCRIPTION
## Overview

The following changes were made to support a Franklin deployment:

- Set up ECS Fargate service behind ALB
- Delegate `noaa.azavea.com` NS to NOAA AWS account
- Create new database for Franklin in staging RDS instance and run migrations

Resolves #15 

## Testing Instructions

See that the health check endpoint is accessible:

```bash
$ http --headers https://franklin.staging.noaa.azavea.com/open-api/spec.yaml
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 27167
Content-Type: text/plain; charset=UTF-8
Date: Thu, 06 Aug 2020 17:46:34 GMT
```