### PR TITLE
Update USFIMR catalog generator to use custom merged SHP

### DIFF
--- a/catalogs/usfimr/.gitignore
+++ b/catalogs/usfimr/.gitignore
@@ -1,1 +1,4 @@
 catalog
+
+data/*
+!data/.gitkeep

--- a/catalogs/usfimr/build_catalog.sh
+++ b/catalogs/usfimr/build_catalog.sh
@@ -1,31 +1,21 @@
 #!/bin/sh
 
-if test -f /tmp/USFIMR_all.zip; then
-  echo "/tmp/USFIMR_all.zip already downloaded. Continuing..."
+if test -f ./data/USFIMR_merged.zip; then
+  echo "USFIMR shapefile already downloaded. Continuing..."
 else
-  echo "/tmp/USFIMR_all.zip not downloaded. Downloading..."
-  wget ftp://guest:guest@sdml-server.ua.edu/USFIMR/USFIMR_all.zip -O /tmp/USFIMR_all.zip
+  echo "Downloading USFIMR shapefile from s3://usfimr-data/shp/USFIMR_merged.zip"
+  aws s3 cp s3://usfimr-data/shp/USFIMR_merged.zip ./data/USFIMR_merged.zip
 fi
 
-if test -d /tmp/USFIMR_all; then
-  echo "/tmp/USFIMR_all.zip already unzipped. Continuing..."
+if test -f ./data/USFIMR_merged.shp; then
+  echo "USFIMR shapefile already unzipped. Continuing..."
 else
-  echo "Unzipping /tmp/USFIMR_all.zip..."
-  unzip /tmp/USFIMR_all.zip -d /tmp
-fi
-
-if test -f /tmp/latlng/USFIMR.shp; then
-  echo "USFIMR already reprojected. Continuing..."
-else
-  echo "Reprojecting USFIMR..."
-  mkdir -p /tmp/latlng
-  # wildcard used here to accomodate dated filenames
-  ogr2ogr /tmp/latlng/USFIMR.shp -t_srs "EPSG:4326" /tmp/USFIMR_all/USFIMR_*.shp
+  unzip ./data/USFIMR_merged.zip -d ./data
 fi
 
 if test -d ./catalog; then
   echo "STAC catalog already exists."
 else
-  echo "STAC catalog not generated."
-  python3 build_catalog.py --shapefile /tmp/latlng/USFIMR.shp
+  echo "Generating STAC Catalog..."
+  python3 build_catalog.py --shapefile ./data/USFIMR_merged.shp
 fi

--- a/catalogs/usfimr/requirements.txt
+++ b/catalogs/usfimr/requirements.txt
@@ -1,3 +1,4 @@
+awscli
 pystac==0.4.0
 rasterio==1.1.5
 shapely==1.7.0


### PR DESCRIPTION
The one on the USFIMR FTP site has bad coordinates.

This one was generated manually according to:
https://github.com/azavea/noaa-flood-mapping/issues/55#issuecomment-674954618

And uploaded to s3://usfimr-data/shp/USFIMR_merged.zip

This commit updates the build_catalog.sh script to pull
our file instead, unzip it and pass it to build_catalog.py

I switched use of /tmp to the ./data dir so that all project
files are contained within this subdir rather than leaving
large files elsewhere on the filesystem.

You'll need the awscli installed to pull the file now,
its added to requirements.txt

Closes #55 

## Demo

![Screen Shot 2020-08-17 at 4 45 38 PM](https://user-images.githubusercontent.com/1818302/90442723-15ea6880-e0a9-11ea-95f6-1fe2ff8b9206.png)
