### PR TITLE
Remove staging identifier from Terraform resources

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -27,7 +27,6 @@ Here is an example `terraform.tfvars` for this project:
 
 ```hcl
 project     = "Flood Map"
-environment = "Staging"
 aws_region  = "us-east-1"
 
 aws_key_name = "floodmap-stg"
@@ -40,13 +39,13 @@ bastion_ami           = "ami-08f3d892de259504d"
 bastion_instance_type = "t3.nano"
 bastion_ebs_optimized = true
 
-rds_database_identifier = floodmap-staging
+rds_database_identifier = floodmap
 rds_database_name       = floodmap
 rds_database_username   = floodmap
 rds_database_password   = floodmap
 ```
 
-This file lives at `s3://noaafloodmap-staging-config-us-east-1/terraform/terraform.tfvars`.
+This file lives at `s3://noaafloodmap-config-us-east-1/terraform/terraform.tfvars`.
 
 To deploy this project's core infrastructure, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
 

--- a/deployment/terraform/alarms.tf
+++ b/deployment/terraform/alarms.tf
@@ -1,3 +1,3 @@
 resource "aws_sns_topic" "global" {
-  name = "topic${replace(var.project, " ", "")}${var.environment}GlobalNotifications"
+  name = "topic${replace(var.project, " ", "")}GlobalNotifications"
 }

--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -7,7 +7,6 @@ resource "aws_security_group" "batch" {
   tags = {
     Name        = "sgBatchContainerInstance"
     Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -55,7 +54,7 @@ resource "aws_launch_template" "batch_gpu_container_instance" {
 resource "aws_batch_compute_environment" "cpu" {
   depends_on = [aws_iam_role_policy_attachment.batch_policy]
 
-  compute_environment_name_prefix = "batch${var.environment}CPUComputeEnvironment"
+  compute_environment_name_prefix = "batchCPUComputeEnvironment"
   type                            = "MANAGED"
   state                           = "ENABLED"
   service_role                    = aws_iam_role.container_instance_batch.arn
@@ -90,7 +89,6 @@ resource "aws_batch_compute_environment" "cpu" {
       Name               = "BatchWorker"
       ComputeEnvironment = "CPU"
       Project            = var.project
-      Environment        = var.environment
     }
   }
 
@@ -102,7 +100,7 @@ resource "aws_batch_compute_environment" "cpu" {
 resource "aws_batch_compute_environment" "gpu" {
   depends_on = [aws_iam_role_policy_attachment.batch_policy]
 
-  compute_environment_name_prefix = "batch${var.environment}GPUComputeEnvironment"
+  compute_environment_name_prefix = "batchGPUComputeEnvironment"
   type                            = "MANAGED"
   state                           = "ENABLED"
   service_role                    = aws_iam_role.container_instance_batch.arn
@@ -137,7 +135,6 @@ resource "aws_batch_compute_environment" "gpu" {
       Name               = "BatchWorker"
       ComputeEnvironment = "GPU"
       Project            = var.project
-      Environment        = var.environment
     }
   }
 
@@ -147,28 +144,28 @@ resource "aws_batch_compute_environment" "gpu" {
 }
 
 resource "aws_batch_job_queue" "cpu" {
-  name                 = "queue${var.environment}CPU"
+  name                 = "queueCPU"
   priority             = 1
   state                = "ENABLED"
   compute_environments = [aws_batch_compute_environment.cpu.arn]
 }
 
 resource "aws_batch_job_queue" "gpu" {
-  name                 = "queue${var.environment}GPU"
+  name                 = "queueGPU"
   priority             = 1
   state                = "ENABLED"
   compute_environments = [aws_batch_compute_environment.gpu.arn]
 }
 
 resource "aws_batch_job_definition" "test_cpu" {
-  name = "job${var.environment}TestCPU"
+  name = "jobTestCPU"
   type = "container"
 
   container_properties = templatefile("job-definitions/test-cpu.json.tmpl", {})
 }
 
 resource "aws_batch_job_definition" "test_gpu" {
-  name = "job${var.environment}TestGPU"
+  name = "jobTestGPU"
   type = "container"
 
   container_properties = templatefile("job-definitions/test-gpu.json.tmpl", {})

--- a/deployment/terraform/database.tf
+++ b/deployment/terraform/database.tf
@@ -9,7 +9,6 @@ resource "aws_db_subnet_group" "default" {
   tags = {
     Name        = "dbsngDatabaseServer"
     Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -61,7 +60,6 @@ resource "aws_db_parameter_group" "default" {
   tags = {
     Name        = "dbpgDatabaseServer"
     Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -100,5 +98,5 @@ module "database" {
   insufficient_data_actions          = [aws_sns_topic.global.arn]
 
   project     = var.project
-  environment = var.environment
+  environment = ""
 }

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -11,7 +11,6 @@ resource "aws_route53_zone" "internal" {
 
   tags = {
     Project     = var.project
-    Environment = var.environment
   }
 }
 

--- a/deployment/terraform/franklin.tf
+++ b/deployment/terraform/franklin.tf
@@ -2,24 +2,22 @@
 # Security Group Resources
 #
 resource "aws_security_group" "alb" {
-  name   = "sg${var.environment}FranklinLoadBalancer"
+  name   = "sgFranklinLoadBalancer"
   vpc_id = module.vpc.id
 
   tags = {
-    Name        = "sg${var.environment}FranklinLoadBalancer",
+    Name        = "sgFranklinLoadBalancer",
     Project     = var.project
-    Environment = var.environment
   }
 }
 
 resource "aws_security_group" "franklin" {
-  name   = "sg${var.environment}FranklinEcsService"
+  name   = "sgFranklinEcsService"
   vpc_id = module.vpc.id
 
   tags = {
-    Name        = "sg${var.environment}FranklinEcsService",
+    Name        = "sgFranklinEcsService",
     Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -27,21 +25,20 @@ resource "aws_security_group" "franklin" {
 # ALB Resources
 #
 resource "aws_lb" "franklin" {
-  name            = "alb${var.environment}Franklin"
+  name            = "albFranklin"
   security_groups = [aws_security_group.alb.id]
   subnets         = module.vpc.public_subnet_ids
 
   enable_http2 = true
 
   tags = {
-    Name        = "alb${var.environment}Franklin"
+    Name        = "albFranklin"
     Project     = var.project
-    Environment = var.environment
   }
 }
 
 resource "aws_lb_target_group" "franklin" {
-  name = "tg${var.environment}Franklin"
+  name = "tgFranklin"
 
   health_check {
     healthy_threshold   = 3
@@ -60,9 +57,8 @@ resource "aws_lb_target_group" "franklin" {
   target_type = "ip"
 
   tags = {
-    Name        = "tg${var.environment}Franklin"
+    Name        = "tgFranklin"
     Project     = var.project
-    Environment = var.environment
   }
 }
 
@@ -98,11 +94,11 @@ resource "aws_lb_listener" "franklin" {
 # ECS Resources
 #
 resource "aws_ecs_cluster" "franklin" {
-  name = "ecs${var.environment}Cluster"
+  name = "ecsCluster"
 }
 
 resource "aws_ecs_task_definition" "franklin" {
-  family                   = "${var.environment}Franklin"
+  family                   = "Franklin"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.franklin_cpu
@@ -120,19 +116,17 @@ resource "aws_ecs_task_definition" "franklin" {
     postgres_name     = "franklin"
     api_host          = aws_route53_record.franklin.name
 
-    environment = var.environment
     aws_region  = var.aws_region
   })
 
   tags = {
-    Name        = "${var.environment}Franklin",
+    Name        = "Franklin",
     Project     = var.project
-    Environment = var.environment
   }
 }
 
 resource "aws_ecs_task_definition" "franklin_migrations" {
-  family                   = "${var.environment}FranklinMigrations"
+  family                   = "FranklinMigrations"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.franklin_migrations_cpu
@@ -149,19 +143,17 @@ resource "aws_ecs_task_definition" "franklin_migrations" {
     postgres_host     = aws_route53_record.database.fqdn
     postgres_name     = "franklin"
 
-    environment = var.environment
     aws_region  = var.aws_region
   })
 
   tags = {
-    Name        = "${var.environment}FranklinMigrations",
+    Name        = "FranklinMigrations"
     Project     = var.project
-    Environment = var.environment
   }
 }
 
 resource "aws_ecs_service" "franklin" {
-  name            = "${var.environment}Franklin"
+  name            = "Franklin"
   cluster         = aws_ecs_cluster.franklin.name
   task_definition = aws_ecs_task_definition.franklin.arn
 
@@ -190,11 +182,11 @@ resource "aws_ecs_service" "franklin" {
 # CloudWatch Resources
 #
 resource "aws_cloudwatch_log_group" "franklin" {
-  name              = "log${var.environment}Franklin"
+  name              = "logFranklin"
   retention_in_days = 30
 }
 
 resource "aws_cloudwatch_log_group" "franklin_migrations" {
-  name              = "log${var.environment}FranklinMigrations"
+  name              = "logFranklinMigrations"
   retention_in_days = 30
 }

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "container_instance_ec2_assume_role" {
 }
 
 resource "aws_iam_role" "container_instance_ec2" {
-  name               = "${var.environment}ContainerInstanceProfile"
+  name               = "ContainerInstanceProfile"
   assume_role_policy = data.aws_iam_policy_document.container_instance_ec2_assume_role.json
 }
 
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "scoped_data" {
 }
 
 resource "aws_iam_role_policy" "scoped_data" {
-  name   = "s3${var.environment}ScopedDataPolicy"
+  name   = "s3ScopedDataPolicy"
   role   = aws_iam_role.container_instance_ec2.name
   policy = data.aws_iam_policy_document.scoped_data.json
 }
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "container_instance_spot_fleet_assume_role" {
 }
 
 resource "aws_iam_role" "container_instance_spot_fleet" {
-  name               = "fleet${var.environment}ServiceRole"
+  name               = "fleetServiceRole"
   assume_role_policy = data.aws_iam_policy_document.container_instance_spot_fleet_assume_role.json
 }
 
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "container_instance_batch_assume_role" {
 }
 
 resource "aws_iam_role" "container_instance_batch" {
-  name               = "batch${var.environment}ServiceRole"
+  name               = "batchServiceRole"
   assume_role_policy = data.aws_iam_policy_document.container_instance_batch_assume_role.json
 }
 
@@ -124,12 +124,12 @@ data "aws_iam_policy_document" "ecs_assume_role" {
 }
 
 resource "aws_iam_role" "ecs_task_execution_role" {
-  name               = "ecs${var.environment}TaskExecutionRole"
+  name               = "ecsTaskExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
 }
 
 resource "aws_iam_role" "ecs_task_role" {
-  name               = "ecs${var.environment}TaskRole"
+  name               = "ecsTaskRole"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
 }
 

--- a/deployment/terraform/network.tf
+++ b/deployment/terraform/network.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "github.com/azavea/terraform-aws-vpc?ref=6.0.1"
 
-  name                       = "vpc${replace(var.project, " ", "")}${var.environment}"
+  name                       = "vpc${replace(var.project, " ", "")}"
   region                     = var.aws_region
   key_name                   = var.aws_key_name
   cidr_block                 = var.vpc_cidr_block
@@ -13,5 +13,5 @@ module "vpc" {
   bastion_ebs_optimized      = var.bastion_ebs_optimized
 
   project     = var.project
-  environment = var.environment
+  environment = ""
 }

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,10 +1,9 @@
 resource "aws_s3_bucket" "data" {
-  bucket = "noaafloodmap-${lower(var.environment)}-data-${var.aws_region}"
+  bucket = "noaafloodmap-data-${var.aws_region}"
   acl    = "private"
 
   tags = {
-    Name        = "noaafloodmap-${lower(var.environment)}-data-${var.aws_region}"
+    Name        = "noaafloodmap-data-${var.aws_region}"
     Project     = var.project
-    Environment = var.environment
   }
 }

--- a/deployment/terraform/task-definitions/franklin.json.tmpl
+++ b/deployment/terraform/task-definitions/franklin.json.tmpl
@@ -33,7 +33,7 @@
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "log${environment}Franklin",
+        "awslogs-group": "logFranklin",
         "awslogs-region": "${aws_region}",
         "awslogs-stream-prefix": "franklin"
       }

--- a/deployment/terraform/task-definitions/franklin_migrations.json.tmpl
+++ b/deployment/terraform/task-definitions/franklin_migrations.json.tmpl
@@ -20,7 +20,7 @@
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {
-        "awslogs-group": "log${environment}FranklinMigrations",
+        "awslogs-group": "logFranklinMigrations",
         "awslogs-region": "${aws_region}",
         "awslogs-stream-prefix": "franklin-migrations"
       }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -3,11 +3,6 @@ variable "project" {
   type    = string
 }
 
-variable "environment" {
-  default = "Staging"
-  type    = string
-}
-
 variable "aws_region" {
   default = "us-east-1"
   type    = string

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,6 +9,6 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-noaa}
       - GIT_COMMIT=${GIT_COMMIT:-latest}
       - NOAA_FLOOD_MAP_DEBUG=1
-      - NOAA_FLOOD_MAP_SETTINGS_BUCKET=${NOAA_FLOOD_MAP_SETTINGS_BUCKET:-noaafloodmap-staging-config-us-east-1}
+      - NOAA_FLOOD_MAP_SETTINGS_BUCKET=${NOAA_FLOOD_MAP_SETTINGS_BUCKET:-noaafloodmap-config-us-east-1}
     working_dir: /usr/local/src
     entrypoint: bash


### PR DESCRIPTION
## Overview

Removes the `environment` variable from Terraform, any references to it, and any staging-related modifiers from resource names.

Resolves #53 

## Testing Instructions

- Verify that staging namespace has been removed from all resources. Attention is called to particular areas in PR comments.