### PR TITLE
Add batch job definition to process CSVs => STAC

### DIFF
--- a/deployment/terraform/batch.tf
+++ b/deployment/terraform/batch.tf
@@ -170,3 +170,10 @@ resource "aws_batch_job_definition" "test_gpu" {
 
   container_properties = templatefile("job-definitions/test-gpu.json.tmpl", {})
 }
+
+resource "aws_batch_job_definition" "s2_catalog_creation" {
+  name = "createSentinel2Catalogs"
+  type = "container"
+
+  container_properties = templatefile("job-definitions/sentinel-2-catalog-creation.json.tmpl", {})
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -56,6 +56,33 @@ resource "aws_iam_role_policy" "scoped_data" {
 #
 # Spot Fleet IAM resources
 #
+
+data "aws_iam_policy_document" "scoped_s2_data" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
+
+    resources = [
+      "arn:aws:s3:::sentinel-inventory",
+      "arn:aws:s3:::sentinel-inventory/*",
+      "arn:aws:s3:::sentinel-s2-l2a",
+      "arn:aws:s3:::sentinel-s2-l2a/*",
+      "arn:aws:s3:::sentinel-s2-l1c",
+      "arn:aws:s3:::sentinel-s2-l1c/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "sentinel_on_aws" {
+  name   = "s3Sentinel2ScopedDataPolicy"
+  role   = aws_iam_role.container_instance_ec2.name
+  policy = data.aws_iam_policy_document.scoped_s2_data.json
+}
+
 data "aws_iam_policy_document" "container_instance_spot_fleet_assume_role" {
   statement {
     effect = "Allow"

--- a/deployment/terraform/job-definitions/sentinel-2-catalog-creation.json.tmpl
+++ b/deployment/terraform/job-definitions/sentinel-2-catalog-creation.json.tmpl
@@ -1,0 +1,33 @@
+{
+    "image": "quay.io/azavea/sentinel-2-stac-utils:0.1.0",
+    "vcpus": 2,
+    "memory": 2048,
+    "command": [
+        "create",
+        "--collection",
+        "Ref::collection",
+        "--inventory-path",
+        "Ref::inventoryPath",
+        "--output-catalog-root",
+        "Ref::outputCatalogRoot"
+    ],
+    "volumes": [
+        {
+            "host": {
+                "sourcePath": "/media/ephemeral0"
+            },
+            "name": "ephemeral0"
+        }
+    ],
+    "environment": [],
+    "mountPoints": [
+        {
+            "containerPath": "/tmp",
+            "readOnly": false,
+            "sourceVolume": "ephemeral0"
+        }
+    ],
+    "privileged": false,
+    "ulimits": [],
+    "resourceRequirements": []
+}


### PR DESCRIPTION
# Overview

This adds a batch job for generating a Sentinel 2 catalog via a CSV.

This job was run successfully to generate some initial catalogs (with some known failures due to the script/container that need to be fixed).

# Testing

I'm not sure what testing should be done -- the job definition is inspectable [here](https://console.aws.amazon.com/batch/home?region=us-east-1#/job-definitions/arn:aws:batch:us-east-1:564456820271:job-definition~2FcreateSentinel2Catalogs:3) and there are successful + failed jobs [here](https://console.aws.amazon.com/batch/home?region=us-east-1#/dashboard).