### PR TITLE
Add validation set generation

### DIFF
--- a/catalogs/sen1floods11-mldata/main.py
+++ b/catalogs/sen1floods11-mldata/main.py
@@ -66,17 +66,11 @@ def train_test_val_split(arrays, train_size, test_size, val_size, random_state):
             )
         )
 
-    test_val_size = test_size + val_size
+    train, test = train_test_split(arrays, test_size=1 - train_size)
+    validation, test = train_test_split(
+        test, test_size=test_size / (test_size + val_size)
+    )
 
-    train, test_val = train_test_split(
-        arrays,
-        train_size=train_size,
-        test_size=test_val_size,
-        random_state=random_state,
-    )
-    test, validation = train_test_split(
-        test_val, train_size=test_size * test_val_size, random_state=random_state,
-    )
     return train, test, validation
 
 
@@ -186,8 +180,8 @@ def main():
     print("Added {} items to train catalog".format(len(train_items)))
     test_collection.add_items(test_items)
     print("Added {} items to test catalog".format(len(test_items)))
-    validation_collection.add_items(test_items)
-    print("Added {} items to test catalog".format(len(test_items)))
+    validation_collection.add_items(val_items)
+    print("Added {} items to validation catalog".format(len(val_items)))
 
     print("Saving catalog...")
     mldata_catalog.normalize_hrefs("./data/mldata_{}".format(experiment))

--- a/catalogs/sen1floods11-mldata/main.py
+++ b/catalogs/sen1floods11-mldata/main.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python3
+
 import argparse
+import sys
 
 import numpy as np
 from pystac import Catalog, CatalogType, Collection, Link, LinkType
@@ -53,6 +56,30 @@ def mapper(item):
     return source_items
 
 
+def train_test_val_split(arrays, train_size, test_size, val_size, random_state):
+    """ A helper function resembling sklearn's train_test_split but with the addition of validation output """
+    proportion_sum = train_size + test_size + val_size
+    if proportion_sum != 1.0:
+        sys.exit(
+            "train, test, validation proprortions must add up to 1.0; currently {}".format(
+                proportion_sum
+            )
+        )
+
+    test_val_size = test_size + val_size
+
+    train, test_val = train_test_split(
+        arrays,
+        train_size=train_size,
+        test_size=test_val_size,
+        random_state=random_state,
+    )
+    test, validation = train_test_split(
+        test_val, train_size=test_size * test_val_size, random_state=random_state,
+    )
+    return train, test, validation
+
+
 def main():
     parser = argparse.ArgumentParser(description="Process some integers.")
     parser.add_argument(
@@ -61,9 +88,17 @@ def main():
         help="Experiment to generate. One of {}".format(set(EXPERIMENT.keys())),
     )
     parser.add_argument(
+        "--sample",
+        "-s",
+        default=1.0,
+        dest="sample",
+        type=normalized_float,
+        help="Percentage of total dataset to build mldata STAC from. Useful for quick experiments",
+    )
+    parser.add_argument(
         "--test-size",
         "-t",
-        default=0.3,
+        default=0.2,
         dest="test_size",
         type=normalized_float,
         help="Percentage of dataset to use for test set",
@@ -71,10 +106,18 @@ def main():
     parser.add_argument(
         "--train-size",
         "-T",
-        default=None,
+        default=0.6,
         dest="train_size",
         type=normalized_float,
         help="Percentage of dataset to use for train set",
+    )
+    parser.add_argument(
+        "--val-size",
+        "-v",
+        default=0.2,
+        dest="val_size",
+        type=normalized_float,
+        help="Percentage of dataset to use for validation set",
     )
     parser.add_argument(
         "--random-seed",
@@ -107,6 +150,11 @@ def main():
     )
     mldata_catalog.add_child(test_collection)
 
+    validation_collection = Collection(
+        "validation", "validation items for collection", label_collection.extent
+    )
+    mldata_catalog.add_child(validation_collection)
+
     mldata_labels_collection = Collection(
         "labels",
         "labels for scenese in test and train collections",
@@ -117,17 +165,28 @@ def main():
     mldata_labels_collection.add_items(label_items)
 
     print("Constructing new ml scenes...")
-    scenes = np.array(list(map(mapper, label_items))).flatten()
-    train_items, test_items = train_test_split(
-        scenes,
-        test_size=args.test_size,
+    all_scenes = np.array(list(map(mapper, label_items))).flatten()
+
+    np.random.seed(seed=args.random_seed)
+    mask = np.random.choice(
+        [False, True], len(all_scenes), p=[1.0 - args.sample, args.sample]
+    )
+    scenes = all_scenes[mask]
+
+    print("args", args.train_size, args.test_size, args.val_size)
+    train_items, test_items, val_items = train_test_val_split(
+        arrays=scenes,
         train_size=args.train_size,
+        test_size=args.test_size,
+        val_size=args.val_size,
         random_state=args.random_seed,
     )
 
     train_collection.add_items(train_items)
     print("Added {} items to train catalog".format(len(train_items)))
     test_collection.add_items(test_items)
+    print("Added {} items to test catalog".format(len(test_items)))
+    validation_collection.add_items(test_items)
     print("Added {} items to test catalog".format(len(test_items)))
 
     print("Saving catalog...")

--- a/inference/rv_stac_config.py
+++ b/inference/rv_stac_config.py
@@ -101,8 +101,8 @@ def build_dataset_from_catalog(
     test_scenes = make_scenes(test_collection, channel_order)
 
     # Read validation scenes from STAC
-    test_collection = catalog.get_child(id="validation")
-    test_scenes = make_scenes(test_collection, channel_order)
+    validation_collection = catalog.get_child(id="validation")
+    validation_scenes = make_scenes(validation_collection, channel_order)
 
     return DatasetConfig(
         class_config=class_config,
@@ -125,7 +125,7 @@ def get_config(runner):
     catalog: Catalog = Catalog.from_file(catalog_root)
 
     # TODO: pull desired channels from root collection properties
-    channel_ordering: [int] = [0, 1, 2]
+    channel_ordering: [int] = [0, 1]
 
     # TODO: pull ClassConfig info from root collection properties
     class_config: ClassConfig = ClassConfig(

--- a/inference/rv_stac_config.py
+++ b/inference/rv_stac_config.py
@@ -100,10 +100,15 @@ def build_dataset_from_catalog(
     test_collection = catalog.get_child(id="test")
     test_scenes = make_scenes(test_collection, channel_order)
 
+    # Read validation scenes from STAC
+    test_collection = catalog.get_child(id="validation")
+    test_scenes = make_scenes(test_collection, channel_order)
+
     return DatasetConfig(
         class_config=class_config,
         train_scenes=train_scenes,
-        validation_scenes=test_scenes,
+        test_scenes=test_scenes,
+        validation_scenes=validation_scenes,
     )
 
 

--- a/inference/rv_stac_config.py
+++ b/inference/rv_stac_config.py
@@ -125,7 +125,7 @@ def get_config(runner):
     catalog: Catalog = Catalog.from_file(catalog_root)
 
     # TODO: pull desired channels from root collection properties
-    channel_ordering: [int] = [0, 1]
+    channel_ordering: [int] = [0, 1, 2]
 
     # TODO: pull ClassConfig info from root collection properties
     class_config: ClassConfig = ClassConfig(


### PR DESCRIPTION
# Overview

This PR addresses the need for a validation set in addition to test and training sets in `mldata` STAC catalogs. To train our models as done in the Sen1Floods11 paper, default values have been set to the same proportions used therein (.6 train/.2 test/.2 validate).

In addition, a random subset of the overall data can be selected for STAC generation to facilitate local training and quick experiments through the command line option `--sample`/`-s`

# Notes

A word of caution when supplying alternative train/test/validation proportions: they'll need to add up to 1.0 or else the program will shoot the user an error message

# Testing

Follow the instructions in the [mldata readme](https://github.com/azavea/noaa-flood-mapping/blob/master/catalogs/sen1floods11-mldata/README.md).
