### PR TITLE
Use canned policies to provide full access to S3

### DIFF
--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -24,65 +24,19 @@ resource "aws_iam_role_policy_attachment" "ec2_service_role" {
   policy_arn = var.aws_ec2_service_role_policy_arn
 }
 
+resource "aws_iam_role_policy_attachment" "s3" {
+  role       = aws_iam_role.container_instance_ec2.name
+  policy_arn = var.aws_s3_full_access_policy_arn
+}
+
 resource "aws_iam_instance_profile" "container_instance" {
   name = aws_iam_role.container_instance_ec2.name
   role = aws_iam_role.container_instance_ec2.name
 }
 
-data "aws_iam_policy_document" "scoped_data" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:GetObject",
-      "s3:PutObject",
-      "s3:PutObjectAcl",
-      "s3:DeleteObject"
-    ]
-
-    resources = [
-      "${aws_s3_bucket.data.arn}",
-      "${aws_s3_bucket.data.arn}/*"
-    ]
-  }
-}
-
-resource "aws_iam_role_policy" "scoped_data" {
-  name   = "s3ScopedDataPolicy"
-  role   = aws_iam_role.container_instance_ec2.name
-  policy = data.aws_iam_policy_document.scoped_data.json
-}
-
 #
 # Spot Fleet IAM resources
 #
-
-data "aws_iam_policy_document" "scoped_s2_data" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:Get*",
-      "s3:List*"
-    ]
-
-    resources = [
-      "arn:aws:s3:::sentinel-inventory",
-      "arn:aws:s3:::sentinel-inventory/*",
-      "arn:aws:s3:::sentinel-s2-l2a",
-      "arn:aws:s3:::sentinel-s2-l2a/*",
-      "arn:aws:s3:::sentinel-s2-l1c",
-      "arn:aws:s3:::sentinel-s2-l1c/*"
-    ]
-  }
-}
-
-resource "aws_iam_role_policy" "sentinel_on_aws" {
-  name   = "s3Sentinel2ScopedDataPolicy"
-  role   = aws_iam_role.container_instance_ec2.name
-  policy = data.aws_iam_policy_document.scoped_s2_data.json
-}
-
 data "aws_iam_policy_document" "container_instance_spot_fleet_assume_role" {
   statement {
     effect = "Allow"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -320,3 +320,8 @@ variable "aws_ecs_task_execution_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
   type    = string
 }
+
+variable "aws_s3_full_access_policy_arn" {
+  default = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  type    = string
+}


### PR DESCRIPTION
Instead of granting access to S3 buckets in a granular way, this makes it so that EC2 instance members of the Batch CEs can freely read and write to any S3 bucket.

---

**Testing**

James is currently working on interacting with S3 buckets that from Batch that are not the project designated data bucket, nor the Sentinel 2 imagery bucket. Success in those efforts should indicate that these changes are having their intended effect.