### PR TITLE
USFIMR S1 MLData Catalog

### DIFF
--- a/catalogs/requirements-conda.txt
+++ b/catalogs/requirements-conda.txt
@@ -7,3 +7,4 @@ pystac==0.4.0
 rasterio==1.1.5
 requests==2.24.0
 shapely==1.7.0
+scikit-learn==0.23.2

--- a/catalogs/usfimr-s1/build_mldata_catalog.py
+++ b/catalogs/usfimr-s1/build_mldata_catalog.py
@@ -1,0 +1,90 @@
+import argparse
+
+import pystac
+
+from stac_utils.s3_io import register_s3_io
+
+
+def add_set(flood_ids, set_type, mldata_catalog, sar_catalog, usfimr_collection):
+    """ Add test, training or validation collections containing flood_ids to mldata_catalog.
+
+    TODO: Properly set the created collection extents. For now they're just set to
+          usfimr_collection.extent since we don't use the extent downstream.
+
+    """
+    set_types = set(["test", "training", "validation"])
+    if set_type not in set_types:
+        raise ValueError("set_type must be one of {}".format(set_types))
+
+    imagery_collection_id = "{}_imagery".format(set_type)
+    labels_collection_id = "{}_labels".format(set_type)
+    if set_type == "test":
+        imagery_collection_id += "_0"
+        labels_collection_id += "_0"
+    imagery_collection = pystac.Collection(
+        imagery_collection_id, imagery_collection_id, usfimr_collection.extent
+    )
+    labels_collection = pystac.Collection(
+        labels_collection_id, labels_collection_id, usfimr_collection.extent
+    )
+
+    for flood_id in flood_ids:
+        usfimr_item = usfimr_collection.get_item(flood_id)
+        usfimr_geojson_asset = usfimr_item.assets["geojson"]
+        usfimr_geojson_asset.set_owner(usfimr_item)
+        usfimr_item_clone = usfimr_item.clone()
+        # Reduce item assets to just the geojson as labels
+        usfimr_item_clone.assets = {"labels": usfimr_item.assets["geojson"]}
+        labels_collection.add_item(usfimr_item_clone)
+
+        for sar_item in sar_catalog.get_child(flood_id).get_items():
+            sar_item_clone = sar_item.clone()
+            sar_item_clone.links.append(
+                pystac.Link(
+                    "labels",
+                    target=usfimr_item_clone,
+                    media_type="application/geo+json",
+                    link_type=pystac.LinkType.RELATIVE,
+                ).set_owner(sar_item_clone)
+            )
+            imagery_collection.add_item(sar_item_clone)
+
+    mldata_catalog.add_child(imagery_collection)
+    mldata_catalog.add_child(labels_collection)
+
+
+def main():
+    register_s3_io()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--usfimr-collection", default="s3://usfimr-data/collection.json"
+    )
+    parser.add_argument("--sar-catalog", required=True, type=str)
+    args = parser.parse_args()
+
+    usfimr_collection = pystac.Collection.from_file(args.usfimr_collection)
+    sar_catalog = pystac.Catalog.from_file(args.sar_catalog)
+
+    # TODO: Do better than to arbitrarily choose these
+    test_set = set(["1"])
+    training_set = set(["2", "3"])
+    validation_set = set(["15", "16"])
+
+    mldata_catalog = pystac.Catalog(
+        "usfimr-s1-mldata", "MLData STAC Catalog for usfimr-s1 dataset"
+    )
+
+    add_set(test_set, "test", mldata_catalog, sar_catalog, usfimr_collection)
+    add_set(training_set, "training", mldata_catalog, sar_catalog, usfimr_collection)
+    add_set(
+        validation_set, "validation", mldata_catalog, sar_catalog, usfimr_collection
+    )
+
+    mldata_catalog.normalize_and_save(
+        "./data/mldata-catalog", catalog_type=pystac.CatalogType.SELF_CONTAINED
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/catalogs/usfimr-s1/build_mldata_catalog.py
+++ b/catalogs/usfimr-s1/build_mldata_catalog.py
@@ -7,12 +7,12 @@ from stac_utils.s3_io import register_s3_io
 from sklearn.model_selection import train_test_split
 
 
-def train_test_val_split(collection, test_size, val_size):
-    train, remain = train_test_split(collection, test_size=(val_size + test_size))
+def train_test_val_split(collection, test_size, val_size, random_state):
+    train, remain = train_test_split(collection, test_size=(val_size + test_size), random_state=random_state)
     new_test_size = np.around(test_size / (val_size + test_size), 2)
     new_val_size = 1.0 - new_test_size
 
-    val, test = train_test_split(remain, test_size=new_test_size)
+    val, test = train_test_split(remain, test_size=new_test_size, random_state=random_state)
     return train, test, val
 
 
@@ -69,7 +69,7 @@ def main():
 
     image_items, labels_collection = collect_items(sar_catalog, usfimr_collection)
 
-    training, testing, validation = train_test_val_split(image_items, 0.2, 0.2)
+    training, testing, validation = train_test_val_split(image_items, 0.2, 0.2, random_state=args.random_seed)
 
     train_collection = pystac.Collection(
         "train", "train", usfimr_collection.extent
@@ -93,7 +93,7 @@ def main():
     mldata_catalog.add_child(val_collection)
 
     mldata_catalog.normalize_and_save(
-        "./data/mldata-catalog", catalog_type=pystac.CatalogType.SELF_CONTAINED
+        "./data/mldata-catalog_seed{}".format(args.random_seed), catalog_type=pystac.CatalogType.SELF_CONTAINED
     )
 
 

--- a/catalogs/usfimr-s1/main.sh
+++ b/catalogs/usfimr-s1/main.sh
@@ -48,3 +48,6 @@ python coregister.py \
 # Re-generate catalog in order to include HAND tifs generated in coregister step
 rm -rf ./data/catalog
 python build_catalog.py --imagery-root-s3 s3://${OUT_BUCKET_4326}
+
+# Build mldata catalog for this dataset
+python build_mldata_catalog.py --sar-catalog ./data/catalog/catalog.json

--- a/catalogs/usfimr-s1/stac_utils/s3_io.py
+++ b/catalogs/usfimr-s1/stac_utils/s3_io.py
@@ -1,14 +1,14 @@
-import urllib3
+from urllib.parse import urlparse
 
 import boto3
 from pystac import STAC_IO
 
 
 def s3_read(uri):
-    parsed = urllib3.util.parse_url(uri)
+    parsed = urlparse(uri)
     if parsed.scheme == "s3":
         bucket = parsed.netloc
-        key = parsed.path[1:]
+        key = parsed.path.lstrip("/")
         s3 = boto3.resource("s3")
         obj = s3.Object(bucket, key)
         return obj.get()["Body"].read().decode("utf-8")
@@ -17,10 +17,10 @@ def s3_read(uri):
 
 
 def s3_write(uri, txt):
-    parsed = urllib3.util.parse_url(uri)
+    parsed = urlparse(uri)
     if parsed.scheme == "s3":
         bucket = parsed.netloc
-        key = parsed.path[1:]
+        key = parsed.path.lstrip("/")
         s3 = boto3.resource("s3")
         s3.Object(bucket, key).put(Body=txt)
     else:

--- a/catalogs/usfimr/build_catalog.py
+++ b/catalogs/usfimr/build_catalog.py
@@ -77,17 +77,17 @@ if __name__ == "__main__":
             fid = feature["id"]
 
             binary_asset = Asset(
-                href="./{}-usfimr.wkb".format(fid),
+                href="{}-usfimr.wkb".format(fid),
                 description="well known binary representation",
                 media_type="application/wkb",
             )
             text_asset = Asset(
-                href="./{}-usfimr.wkt".format(fid),
+                href="{}-usfimr.wkt".format(fid),
                 description="well known text representation",
                 media_type="application/wkt",
             )
             json_asset = Asset(
-                href="./{}-usfimr.geojson".format(fid),
+                href="{}-usfimr.geojson".format(fid),
                 description="geojson representation",
                 media_type="application/geo+json",
             )
@@ -95,8 +95,11 @@ if __name__ == "__main__":
             item = Item(
                 fid, serializable_convex_hull, bbox_list, start_dt, deepcopy(props)
             )
+            text_asset.set_owner(item)
             item.add_asset(key="wkt", asset=text_asset)
+            binary_asset.set_owner(item)
             item.add_asset(key="wkb", asset=binary_asset)
+            json_asset.set_owner(item)
             item.add_asset(key="geojson", asset=json_asset)
             items.append(item)
 


### PR DESCRIPTION
# Overview

Generates an mldata catalog of the same structure as `./catalogs/sen1floods11-mldata` but for the usfimr-s1 catalog generated in `./catalogs/usfimr-s1`. 

This PR remains in draft form because I'm awaiting guidance on how to do the test, train, validation splits. Otherwise, we could write a new rv_stac_config over in `./inference` with what's here and run a RV prediction, even if it does generate nonsense based on the current test, train, validation splits.

Here's the generated catalog for your perusal:

[usfimr-s1-mldata-catalog.zip](https://github.com/azavea/noaa-flood-mapping/files/5211109/usfimr-s1-mldata-catalog.zip)

Closes #57 
