### PR TITLE
Mississippi river system S1 ingest

### DIFF
--- a/catalogs/mississippi-s1/README.md
+++ b/catalogs/mississippi-s1/README.md
@@ -1,0 +1,24 @@
+# Mississippi River Correlated S1 Imagery ~~STAC Catalog~~
+
+This project is responsible for generating an S1 dataset correlated with the Mississippi river system for the purposes of training against monthly JRC data. There is currently no corresponding STAC catalog for this imagery. That work will be completed later, in anticipation of training RV models
+
+In order to generate the correctly projected S1 imagery, the following steps are performed:
+
+1a. Compute intersection of S1 chips and the region of interest over the Mississippi river system via the SentinelHub Search API (`ingest_s1.py`)
+1b. Retrieve orthorectified S1 GRD chips intersecting each USFIMR flood area via the SentinelHub Batch API, saved to an S3 bucket (also `ingest_s1.py`)
+
+```bash
+./ingest_s1.py --oauth-id '<sentinel-hub-oauth-id>' --oauth-secret '<sentinel-hub-oauth-secret>' --sentinelhub-bucket noaafloodmapping-sentinelhub-batch-eu-central-1
+```
+
+2a. Boot up an ec2 instance (prefer a large, compute optimized instance as there are many smallish tiffs to work through).
+2b. Install GDAL and gnu-parallel (`aws_install_deps.sh`)
+2c. Reproject SentinelHub S1 GRD chips to 4326 and save to an S3 bucket (`reproject_tiffs.sh`). This is also a good time to move data outside the EU if that happens to be desirable
+
+```bash
+./aws_install_deps.sh
+# assuming 36 cores as, e.g., with c5.9xlarge
+./reproject_tiffs.sh s3://noaafloodmapping-sentinelhub-batch-eu-central-1/mississippi-surface-water s3://mississippi-sar-4326 36
+```
+
+Unlike other subdirectories within `../catalog`, `main.sh` is not used to generate this data. This is because this process is expensive in time and storage costs. Proceed with care.

--- a/catalogs/mississippi-s1/aws_install_deps.sh
+++ b/catalogs/mississippi-s1/aws_install_deps.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This file is written in anticipation of being run on the AWS version 2 series AMI
+
+sudo yum -y update
+sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+sudo yum-config-manager --enable epel
+sudo yum -y install make automake gcc gcc-c++ libcurl-devel proj-devel geos-devel
+cd /tmp
+curl -L http://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz | tar zxf -
+cd gdal-2.4.2/
+./configure --prefix=/usr/local --without-python
+make -j4
+sudo make install
+cd /usr/local
+tar zcvf ~/gdal-2.4.2-amz1.tar.gz *
+
+
+# Installing gnu-parallel (quick and dirty)
+(wget -O - pi.dk/3 || lynx -source pi.dk/3 || curl pi.dk/3/ || fetch -o - http://pi.dk/3 ) > install.sh
+bash install.sh

--- a/catalogs/mississippi-s1/ingest_s1.py
+++ b/catalogs/mississippi-s1/ingest_s1.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+import argparse
+from datetime import date, time, datetime
+import logging
+import sys
+
+import boto3
+from dateutil import rrule, relativedelta
+
+from request_builders import (
+    get_sentinel_hub_session,
+    search_sentinelhub_s1,
+    create_batch_request,
+    analyze_batch_request,
+    initiate_batch_request,
+    check_batch_status,
+)
+from stac_utils.s3_io import register_s3_io
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--oauth-id",
+        required=True,
+        type=str,
+        help="OAuth ID for requesting an authorization token",
+    )
+    parser.add_argument(
+        "--oauth-secret",
+        required=True,
+        type=str,
+        help="OAuth secret for requesting an authorization token",
+    )
+    parser.add_argument(
+        "--sentinelhub-bucket",
+        required=True,
+        type=str,
+        help="The bucket that should contain the output of the SentinelHub Batch Ingests",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    parser = make_parser()
+    args = parser.parse_args()
+
+    # Register methods for IO to/from S3
+    register_s3_io()
+
+    # Set S3 write directory
+    s3 = boto3.resource("s3")
+    bucket = s3.Bucket(args.sentinelhub_bucket)
+
+    session = get_sentinel_hub_session(args.oauth_id, args.oauth_secret)
+
+    # geom bounds
+    bbox = [
+        -88.02592402528022,
+        29.038948834106055,
+        -92.72807246278022,
+        42.55475543734189,
+    ]
+
+    # temporal bounds
+    # The JRC water dataset examines imagery from march, 1984 to december, 2019
+    # S1 coverage starts in 2016 and, in this region, November
+    date_iter_start = datetime.combine(date(2016, 11, 1), time.min)
+    date_iter_end = datetime.combine(date(2019, 12, 1), time.min)
+
+    for dt_min in rrule.rrule(
+        rrule.MONTHLY, dtstart=date_iter_start, until=date_iter_end
+    ):
+        month_name = "{year}_{month}".format(year=dt_min.year, month=dt_min.month)
+        dt_max = dt_min + relativedelta.relativedelta(
+            day=31, hour=23, minute=59, second=59
+        )
+        search_results = search_sentinelhub_s1(dt_min, dt_max, bbox, session)
+        search_results = search_results.json()
+
+        result_count = search_results["context"]["returned"]
+        if result_count > 0:
+            logger.info(
+                "{result_count} results for {month}".format(
+                    result_count=result_count, month=month_name
+                )
+            )
+
+        else:
+            logger.info("No S1 results found for {month}".format(month=month_name))
+            continue
+
+        # Check if data is already loaded
+        ingest_prefix = "mississippi-surface-water/{month}/".format(month=month_name)
+        filtered_bucket_contents = bucket.objects.filter(Prefix=ingest_prefix)
+        already_loaded = False
+        for key in filtered_bucket_contents:
+            already_loaded = True
+            break
+
+        if already_loaded:
+            logger.info("Month {} already ingested, skipping".format(month_name))
+        else:
+            logger.info("Month {} not ingested, ingesting".format(month_name))
+            # temporal bounds
+            batch_ingest_path = (
+                "s3://{bucket}/{ingest_prefix}<tileName>/<outputId>.tiff".format(
+                    bucket=bucket.name, ingest_prefix=ingest_prefix
+                )
+            )
+            batch_creation_request = create_batch_request(
+                bbox, dt_min, dt_max, batch_ingest_path, session
+            )
+            batch_creation_response = batch_creation_request.json()
+            print("Batch response", batch_creation_response)
+            batch_request_id = batch_creation_response["id"]
+            logger.info("Month: {}; ingest ID: {}".format(month_name, batch_request_id))
+
+            analyze_batch_request(batch_request_id, session)
+
+            initiate_batch_request(batch_request_id, session)
+
+            for count in range(100):
+                status_response = check_batch_status(batch_request_id, session)
+                status_response_data = status_response.json()
+                status = status_response_data["status"]
+
+                if status == "DONE":
+                    logger.info(
+                        "S1 ingest for {} completed successfully.".format(month_name)
+                    )
+                    logger.info("SUCCESSFUL REQUEST ID: {}".format(batch_request_id))
+                    logger.info("Data ingested to {}".format(batch_ingest_path))
+                    break
+                elif status == "FAILED":
+                    logger.info("S1 ingest for {} FAILED".format(month_name))
+                    logger.debug(status_response_data)

--- a/catalogs/mississippi-s1/ingest_s1.py
+++ b/catalogs/mississippi-s1/ingest_s1.py
@@ -117,7 +117,6 @@ if __name__ == "__main__":
                 bbox, dt_min, dt_max, batch_ingest_path, session
             )
             batch_creation_response = batch_creation_request.json()
-            print("Batch response", batch_creation_response)
             batch_request_id = batch_creation_response["id"]
             logger.info("Month: {}; ingest ID: {}".format(month_name, batch_request_id))
 

--- a/catalogs/mississippi-s1/ingest_s1_evalscript.js
+++ b/catalogs/mississippi-s1/ingest_s1_evalscript.js
@@ -1,0 +1,27 @@
+//VERSION=3
+function setup() {
+  return {
+    input: ["VV", "VH", "dataMask"],
+    output: [{
+      id: "VV",
+      bands: 1,
+      sampleType: "FLOAT32"
+    }, {
+      id: "VH",
+      bands: 1,
+      sampleType: "FLOAT32"
+    }, {
+      id: "MASK",
+      bands: 1,
+      sampleType: "UINT8"
+    }]
+  };
+}
+
+function evaluatePixel(samples) {
+  return {
+    VV: [samples.VV],
+    VH: [samples.VH],
+    MASK: [samples.dataMask]
+  };
+}

--- a/catalogs/mississippi-s1/reproject_tiffs.sh
+++ b/catalogs/mississippi-s1/reproject_tiffs.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+export INPUT_ROOT=$1
+export INPUT_BUCKET=$(echo $1 | cut -d '/' -f 3)
+export OUTPUT_ROOT=$2
+export OUTPUT_BUCKET=$(echo $2 | cut -d '/' -f 3)
+export PARALLELISM=${3:-4}
+
+
+# requires path (minus bucket)
+function reproject_to_new_root {
+  IN_PATH="s3://${INPUT_BUCKET}/$1"
+  OUT_PATH="s3://${OUTPUT_BUCKET}/$1"
+  TEMP_UTM=$(mktemp /tmp/utm.XXXXXXXXXXXXXXXXXXXXXXX.tiff)
+  TEMP_4326=$(mktemp /tmp/4326.XXXXXXXXXXXXXXXXXXXXXXX.tiff)
+  echo "Reprojecting from ${IN_PATH} to ${OUT_PATH}"
+  aws s3 cp $IN_PATH $TEMP_UTM
+  gdalwarp -overwrite -r bilinear -t_srs EPSG:4326 $TEMP_UTM $TEMP_4326
+  aws s3 cp $TEMP_4326 ${OUT_PATH}
+  echo "Successfully wrote to ${OUT_PATH}"
+  rm -rf $TEMP_4326
+  rm -rf $TEMP_UTM
+}
+
+
+function main {
+  # size
+  S=`echo $1 | tr -s ' ' | cut -d ' ' -f 3`
+  # path
+  P=`echo $1 | tr -s ' ' | cut -d ' ' -f 4`
+  FILE_EXT=${P##*.}
+
+  if [ "$FILE_EXT" = "tiff" ]; then
+    # An empty mask should be 5837 bytes
+    if [ $(basename $P) = "MASK.tiff" ] && [ "$S" -gt 5837 ]; then
+      echo "working on $P"
+      reproject_to_new_root $P
+
+    # An empty vv/vh should be 60815 bytes
+    elif [ "$S" -gt 60815 ]; then
+      echo "working on $P"
+      reproject_to_new_root $P
+    else
+      echo "SKIPPING $P, size $S"
+    fi
+  else
+    echo "File without .tiff extension encountered: $P"
+  fi
+}
+
+export -f reproject_to_new_root
+export -f main
+export IFS=$'\n'
+aws s3 ls --recursive ${INPUT_ROOT} | parallel -j $PARALLELISM -n 1 main {}

--- a/catalogs/mississippi-s1/request_builders.py
+++ b/catalogs/mississippi-s1/request_builders.py
@@ -27,7 +27,6 @@ def get_sentinel_hub_session(oauth_id, oauth_secret):
             "Logged in. Sentinel-Hub session valid until {}".format(one_hour_later)
         )
         access_token = response.json()["access_token"]
-        print('token', access_token)
         session = requests.Session()
         session.headers.update(
             {
@@ -129,7 +128,6 @@ def create_batch_request(bbox, min_date, max_date, ingest_path, session):
         },
     }
     encoded = json.dumps(parameters).encode("utf-8")
-    print("sesstest", session.headers)
 
     creation_request = session.post(
         "{}/api/v1/batch/process/".format(SENTINEL_HUB_HOSTNAME), data=encoded

--- a/catalogs/mississippi-s1/request_builders.py
+++ b/catalogs/mississippi-s1/request_builders.py
@@ -1,0 +1,184 @@
+import datetime
+import json
+import logging
+import sys
+import time
+
+import requests
+
+SENTINEL_HUB_HOSTNAME = "https://services.sentinel-hub.com"
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def get_sentinel_hub_session(oauth_id, oauth_secret):
+    response = requests.post(
+        "{}/oauth/token".format(SENTINEL_HUB_HOSTNAME),
+        data={
+            "grant_type": "client_credentials",
+            "client_id": oauth_id,
+            "client_secret": oauth_secret,
+        },
+    )
+    if response.status_code == 200:
+        one_hour_later = datetime.datetime.now() + datetime.timedelta(hours=1)
+        logger.info(
+            "Logged in. Sentinel-Hub session valid until {}".format(one_hour_later)
+        )
+        access_token = response.json()["access_token"]
+        print('token', access_token)
+        session = requests.Session()
+        session.headers.update(
+            {
+                "Authorization": "Bearer {}".format(access_token),
+                "Content-Type": "application/json",
+            }
+        )
+        return session
+    else:
+        sys.exit(
+            "Failure to acquire Sentine-Hub token. Status: {}".format(
+                response.status_code
+            )
+        )
+
+
+def search_sentinelhub_s1(date_min, date_max, bbox, session):
+    """ Example curl:
+        curl -X "POST" "https://services.sentinel-hub.com/api/v1/catalog/search" \
+            -H 'Content-Type: application/json' \
+            -H 'Authorization: Bearer <token>' \
+            -d $'{
+                "limit": 1,
+                "fields": {
+                    "include": [
+                        "properties.eo:gsd"
+                    ]
+                },
+                "datetime": "2019-05-22T00:00:00Z/2019-05-23T00:00:00Z",
+                "collections": [
+                    "sentinel-1-grd"
+                ],
+                "bbox": [
+                    -94.3670654296875,
+                    38.371808917147554,
+                    -95.712890625,
+                    40.30885442563764
+                ]
+            }'
+    """
+    datetime_str = "{}Z/{}Z".format(date_min.isoformat(), date_max.isoformat())
+    parameters = {
+        "limit": 300,
+        "fields": {"include": ["properties.eo:gsd"]},
+        "datetime": datetime_str,
+        "collections": ["sentinel-1-grd"],
+        "bbox": bbox,
+    }
+    logger.debug("search_sentinelhub_s1 params: {}".format(parameters))
+    encoded = json.dumps(parameters).encode("utf-8")
+    return session.post(
+        "{}/api/v1/catalog/search".format(SENTINEL_HUB_HOSTNAME),
+        data=encoded,
+    )
+
+
+def create_batch_request(bbox, min_date, max_date, ingest_path, session):
+    with open("ingest_s1_evalscript.js", "r") as script:
+        evalscript = script.read()
+    parameters = {
+        "tilingGrid": {"id": 0, "resolution": "10"},
+        "output": {"cogOutput": True, "defaultTilePath": ingest_path},
+        "description": "Batch request for S1 data related to Mississippi river system; month: {}_{}".format(
+            min_date.year, min_date.month
+        ),
+        "processRequest": {
+            "input": {
+                "bounds": {
+                    "bbox": bbox,
+                    "properties": {"crs": "http://www.opengis.net/def/crs/EPSG/0/4326"},
+                },
+                "data": [
+                    {
+                        "type": "S1GRD",
+                        "processing": {
+                            "backCoeff": "SIGMA0_ELLIPSOID",
+                            "orthorectify": True,
+                        },
+                        "dataFilter": {
+                            "timeRange": {
+                                "from": min_date.isoformat() + "Z",
+                                "to": max_date.isoformat() + "Z",
+                            },
+                            "polarization": "DV",
+                            "acquisitionMode": "IW",
+                            "resolution": "HIGH",
+                        },
+                    }
+                ],
+            },
+            "evalscript": evalscript,
+            "output": {
+                "responses": [
+                    {"format": {"type": "image/tiff"}, "identifier": "VV"},
+                    {"format": {"type": "image/tiff"}, "identifier": "VH"},
+                    {"format": {"type": "image/tiff"}, "identifier": "MASK"},
+                ]
+            },
+        },
+    }
+    encoded = json.dumps(parameters).encode("utf-8")
+    print("sesstest", session.headers)
+
+    creation_request = session.post(
+        "{}/api/v1/batch/process/".format(SENTINEL_HUB_HOSTNAME), data=encoded
+    )
+    return creation_request
+
+
+def check_batch_status(request_id, session):
+    """
+    GET https://services.sentinel-hub.com/api/v1/batch/process/<batch_request_id>
+    """
+    return session.get(
+        "{}/api/v1/batch/process/{}".format(SENTINEL_HUB_HOSTNAME, request_id)
+    )
+
+
+def analyze_batch_request(request_id, session):
+    """
+    POST https://services.sentinel-hub.com/api/v1/batch/process/<batch_request_id>/analyse.
+    GET https://services.sentinel-hub.com/api/v1/batch/process/<batch_request_id>
+    """
+    session.post(
+        "{}/api/v1/batch/process/{}/analyse".format(SENTINEL_HUB_HOSTNAME, request_id)
+    )
+    for count in range(100):
+        check = check_batch_status(request_id, session)
+        response_data = check.json()
+        status = response_data["status"]
+        print("Status check {}/100: {}".format(count, status))
+        if status == "ANALYSIS_DONE":
+            print(
+                "Tile estimate: {tiles} tiles; Value estimate: {value} processing units".format(
+                    tiles=response_data["tileCount"],
+                    value=response_data["valueEstimate"],
+                )
+            )
+            return check
+        elif status == "FAILED":
+            print("STATUS: FAILED")
+            print(response_data)
+            break
+        else:
+            time.sleep(10)
+
+
+def initiate_batch_request(request_id, session):
+    """
+    POST https://services.sentinel-hub.com/api/v1/batch/process/<batch_request_id>/start
+    """
+    return session.post(
+        "{}/api/v1/batch/process/{}/start".format(SENTINEL_HUB_HOSTNAME, request_id)
+    )

--- a/catalogs/mississippi-s1/stac_utils/s3_io.py
+++ b/catalogs/mississippi-s1/stac_utils/s3_io.py
@@ -1,0 +1,32 @@
+from urllib.parse import urlparse
+
+import boto3
+from pystac import STAC_IO
+
+
+def s3_read(uri):
+    parsed = urlparse(uri)
+    if parsed.scheme == "s3":
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        s3 = boto3.resource("s3")
+        obj = s3.Object(bucket, key)
+        return obj.get()["Body"].read().decode("utf-8")
+    else:
+        return STAC_IO.default_read_text_method(uri)
+
+
+def s3_write(uri, txt):
+    parsed = urlparse(uri)
+    if parsed.scheme == "s3":
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        s3 = boto3.resource("s3")
+        s3.Object(bucket, key).put(Body=txt)
+    else:
+        STAC_IO.default_write_text_method(uri, txt)
+
+
+def register_s3_io():
+    STAC_IO.read_text_method = s3_read
+    STAC_IO.write_text_method = s3_write

--- a/catalogs/requirements-conda.txt
+++ b/catalogs/requirements-conda.txt
@@ -8,3 +8,4 @@ rasterio==1.1.5
 requests==2.24.0
 shapely==1.7.0
 scikit-learn==0.23.2
+python-dateutil==2.8.1

--- a/catalogs/requirements-conda.txt
+++ b/catalogs/requirements-conda.txt
@@ -1,11 +1,11 @@
-Fiona==1.8.13
 awscli
 boto3==1.14.20
+Fiona==1.8.13
 ipdb
 ipython==7.18.1
 pystac==0.4.0
+python-dateutil==2.8.1
 rasterio==1.1.5
 requests==2.24.0
-shapely==1.7.0
 scikit-learn==0.23.2
-python-dateutil==2.8.1
+shapely==1.7.0


### PR DESCRIPTION
# Overview

This PR adds the scripts necessary to grab all S1 SAR data overlapping the Mississippi river from Sentinel-Hub as well as to reproject it appropriately (and to get it out of the EU).

There are two separate steps:
1. Run the Sentinel-Hub ingest 
```
./ingest_s1.py --oauth-id '<id>' --oauth-secret '<secret>' --sentinelhub-bucket noaafloodmapping-sentinelhub-batch-eu-central-1
```
2. Boot up an EC2 instance (prioritize compute/number of cores). On that instance, run `aws_install_deps.sh` to prepare GDAL and gnu-parallel. Once that is complete, run `reproject_tiffs.sh` providing the root of the directory that holds the ingested S1 images, the location you'd like to dump reprojected tiffs, and the parallelism (likely just the number of cores). Here's the command I used on a C5.9xlarge with 36 cores:
```
./reproject_tiffs.sh s3://noaafloodmapping-sentinelhub-batch-eu-central-1/mississippi-surface-water s3://mississippi-sar-4326 36
```
