### PR TITLE
Set up CI for catalogs image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,42 @@
+#!groovy
+
+node {
+  try {
+    env.COMPOSE_PROJECT_NAME = "noaa-flood-mapping-${env.BRANCH_NAME}-${env.BUILD_NUMBER}"
+
+    stage('checkout') {
+      checkout scm
+    }
+
+    stage('cibuild') {
+      wrap([$class: 'AnsiColorBuildWrapper']) {
+        sh './scripts/cibuild'
+      }
+    }
+
+    if (currentBuild.currentResult == 'SUCCESS' && currentBuild.previousBuild?.result != 'SUCCESS') {
+      def slackMessage = ":jenkins: *Flood Mapping (${env.BRANCH_NAME}) #${env.BUILD_NUMBER}*"
+      if (env.CHANGE_TITLE) {
+        slackMessage += "\n${env.CHANGE_TITLE} - ${env.CHANGE_AUTHOR}"
+      }
+      slackMessage += "\n<${env.BUILD_URL}|View Build>"
+      slackSend channel: '#noaa-flood-mapping', color: 'good', message: slackMessage
+    }
+  } catch (err) {
+    // Some exception was raised in the `try` block above. Assemble
+    // an appropriate error message for Slack.
+    def slackMessage = ":jenkins-angry: *Flood Mapping (${env.BRANCH_NAME}) #${env.BUILD_NUMBER}*"
+    if (env.CHANGE_TITLE) {
+      slackMessage += "\n${env.CHANGE_TITLE} - ${env.CHANGE_AUTHOR}"
+    }
+    slackMessage += "\n<${env.BUILD_URL}|View Build>"
+    slackSend  channel: '#noaa-flood-mapping', color: 'danger', message: slackMessage
+
+    // Re-raise the exception so that the failure is propagated to Jenkins.
+    throw err
+  } finally {
+    // Pass or fail, ensure that the services and networks created by Docker
+    // Compose are torn down.
+    sh 'docker-compose down -v'
+  }
+}

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@
 
 | Name                    | Description                                                 |
 | ----------------------- | ------------------------------------------------------------|
+| `cibuild`               | Build application for staging or a release.                 |
 | `infra`                 | Execute Terraform subcommands with remote state management. |

--- a/catalogs/.dockerignore
+++ b/catalogs/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+Dockerfile
+README.md

--- a/catalogs/.dockerignore
+++ b/catalogs/.dockerignore
@@ -1,3 +1,0 @@
-.dockerignore
-Dockerfile
-README.md

--- a/catalogs/Dockerfile
+++ b/catalogs/Dockerfile
@@ -1,6 +1,5 @@
 FROM continuumio/miniconda3
 
-
 RUN apt update \
   && apt install -y --no-install-recommends unzip \
   && rm -rf /var/lib/apt/lists/*
@@ -20,5 +19,7 @@ COPY ./requirements-pip.txt /tmp/requirements-pip.txt
 RUN pip install -r /tmp/requirements-pip.txt
 
 WORKDIR /opt/catalogs
+
+COPY ./main.sh main.sh
 
 ENTRYPOINT [ "./main.sh" ]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,8 @@
 version: "2.4"
 services:
+  catalogs:
+    image: "noaa-flood-catalogs:${GIT_COMMIT:-latest}"
+
   terraform:
     image: quay.io/azavea/terraform:0.12.29
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: ./catalogs
     image: noaa-flood-catalogs
     environment:
-      - AWS_PROFILE=noaa-flood
+      - AWS_PROFILE=${AWS_PROFILE:-noaa}
       - SENTINELHUB_OAUTH_ID
       - SENTINELHUB_OAUTH_SECRET
     volumes:

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${NOAA_FLOOD_MAP_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Build application for staging or a release.
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        # Build tagged container images
+        GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.ci.yml \
+            build catalogs
+    fi
+fi

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -19,8 +19,8 @@ else
     GIT_COMMIT="$(git rev-parse --short HEAD)"
 fi
 
-if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    if [ "${1:-}" = "--help" ]; then
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    if [[ "${1:-}" == "--help" ]]; then
         usage
     else
         # Build tagged container images


### PR DESCRIPTION
## Overview

Sets up the `cibuild` script and runs it during the Jenkins build for the `noaa-flood-catalogs` image.

## Notes

The `inference` image will be built in CI as part of #64.

## Testing Instructions

- Confirm that the [Jenkins build](http://jenkins.staging.rasterfoundry.com/job/Azavea/job/noaa-flood-mapping/view/change-requests/job/PR-92/2/) passes.
- Run `./scripts/cibuild` locally and confirm that the image builds successfully.
- Run `AWS_PROFILE=noaa docker-compose run --rm catalogs usfimr` to test building the `usfimr` STAC catalog. This will take a few minutes. You should see output similar to the following:
  ```
  Creating noaa-flood-mapping_catalogs_run ... done
  Downloading USFIMR shapefile from s3://usfimr-data/shp/USFIMR_merged.zip
  download: s3://usfimr-data/shp/USFIMR_merged.zip to data/USFIMR_merged.zip
  Archive:  ./data/USFIMR_merged.zip
    inflating: ./data/USFIMR_merged.dbf  
    inflating: ./data/USFIMR_merged.prj  
    inflating: ./data/USFIMR_merged.shp  
    inflating: ./data/USFIMR_merged.shx  
  Generating STAC Catalog...
  ERROR 1: PROJ: proj_create_from_database: Open of /opt/conda/envs/env/share/proj failed
  Targeting shapefile at path ./data/USFIMR_merged.shp
  Saved STAC Catalog USFIMR to ./data/catalog...
  ```

Resolves #80 