### PR TITLE
Build and publish pipeline Docker image to ECR repositories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/')) {
+    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME == 'PR-96') {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
       }
     }
 
-    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME == 'PR-96') {
+    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/')) {
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
       // first seven characters of the revision SHA.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,28 @@ node {
       checkout scm
     }
 
+    env.AWS_PROFILE = 'noaa'
+    env.AWS_DEFAULT_REGION = 'us-east-1'
+
     stage('cibuild') {
       wrap([$class: 'AnsiColorBuildWrapper']) {
         sh './scripts/cibuild'
+      }
+    }
+
+    if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME.startsWith('test/') || env.BRANCH_NAME.startsWith('release/')) {
+      // Publish container images built and tested during `cibuild`
+      // to the private Amazon Container Registry tagged with the
+      // first seven characters of the revision SHA.
+      stage('cipublish') {
+        // Decode the ECR endpoint stored within Jenkins.
+        withCredentials([[$class: 'StringBinding',
+                credentialsId: 'NOAA_AWS_ECR_ENDPOINT',
+                variable: 'NOAA_AWS_ECR_ENDPOINT']]) {
+          wrap([$class: 'AnsiColorBuildWrapper']) {
+            sh './scripts/cipublish'
+          }
+        }
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ node {
       checkout scm
     }
 
-    env.AWS_PROFILE = 'noaa'
     env.AWS_DEFAULT_REGION = 'us-east-1'
 
     stage('cibuild') {
@@ -23,11 +22,22 @@ node {
       // first seven characters of the revision SHA.
       stage('cipublish') {
         // Decode the ECR endpoint stored within Jenkins.
-        withCredentials([[$class: 'StringBinding',
-                credentialsId: 'NOAA_AWS_ECR_ENDPOINT',
-                variable: 'NOAA_AWS_ECR_ENDPOINT']]) {
+        withCredentials([
+          [
+            $class: 'StringBinding',
+            credentialsId: 'NOAA_AWS_ECR_ENDPOINT',
+            variable: 'NOAA_AWS_ECR_ENDPOINT'
+          ],
+          [
+            $class: 'StringBinding',
+            credentialsId: 'NOAA_AWS_DEPLOY_ROLE_ARN',
+            variable: 'NOAA_AWS_DEPLOY_ROLE_ARN'
+          ],
+        ]) {
           wrap([$class: 'AnsiColorBuildWrapper']) {
-            sh './scripts/cipublish'
+            withAWS(role: env.NOAA_AWS_DEPLOY_ROLE_ARN) {
+              sh './scripts/cipublish'
+            }
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Scripts
 
-| Name                    | Description                                                 |
-| ----------------------- | ------------------------------------------------------------|
-| `cibuild`               | Build application for staging or a release.                 |
-| `infra`                 | Execute Terraform subcommands with remote state management. |
+| Name                    | Description                                                   |
+| ----------------------- | --------------------------------------------------------------|
+| `cibuild`               | Build application for staging or a release.                   |
+| `cipublish`             | Publish container images to Elastic Container Registry (ECR). |
+| `infra`                 | Execute Terraform subcommands with remote state management.   |

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -43,6 +43,8 @@ rds_database_identifier = floodmap
 rds_database_name       = floodmap
 rds_database_username   = floodmap
 rds_database_password   = floodmap
+
+aws_azavea_account_id = "123456789012"
 ```
 
 This file lives at `s3://noaafloodmap-config-us-east-1/terraform/terraform.tfvars`.

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -14,6 +14,11 @@ data "aws_iam_policy_document" "assume_deploy_role" {
   }
 }
 
+# This role requires a trust relationship to be established with the Raster
+# Foundry AWS account. The Raster Foundry Jenkins instance profile needs to
+# have the NOAA AWS account ID added to the list of principals in its
+# attached AssumeRole policy. This will allow it to assume the cross-account
+# deploy role.
 resource "aws_iam_role" "deploy" {
   name               = "AzaveaDeploy"
   assume_role_policy = data.aws_iam_policy_document.assume_deploy_role.json

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "assume_deploy_role" {
 
     principals {
       type = "AWS"
-      identifiers = [var.aws_azavea_account_id]
+      identifiers = [var.aws_raster_foundry_account_id]
     }
 
     actions = ["sts:AssumeRole"]

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -1,4 +1,31 @@
 #
+# Cross-account deployment role IAM resources
+#
+data "aws_iam_policy_document" "assume_deploy_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [var.aws_azavea_account_id]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "deploy" {
+  name               = "AzaveaDeploy"
+  assume_role_policy = data.aws_iam_policy_document.assume_deploy_role.json
+  description        = "Role assumed to execute CI based deployments for Azavea."
+}
+
+resource "aws_iam_role_policy_attachment" "deploy" {
+  role       = aws_iam_role.deploy.name
+  policy_arn = var.aws_administrator_policy_arn
+}
+
+#
 # Container Instance IAM resources
 #
 data "aws_iam_policy_document" "container_instance_ec2_assume_role" {

--- a/deployment/terraform/storage.tf
+++ b/deployment/terraform/storage.tf
@@ -1,3 +1,17 @@
+module "ecr_catalogs" {
+  source = "github.com/azavea/terraform-aws-ecr-repository?ref=1.0.0"
+
+  repository_name         = "noaa-flood-catalogs"
+  attach_lifecycle_policy = true
+}
+
+module "ecr_pipeline" {
+  source = "github.com/azavea/terraform-aws-ecr-repository?ref=1.0.0"
+
+  repository_name         = "noaa-flood-pipeline"
+  attach_lifecycle_policy = true
+}
+
 resource "aws_s3_bucket" "data" {
   bucket = "noaafloodmap-data-${var.aws_region}"
   acl    = "private"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -301,6 +301,15 @@ variable "franklin_migrations_memory" {
   type = number
 }
 
+variable "aws_azavea_account_id" {
+  type = string
+}
+
+variable "aws_administrator_policy_arn" {
+  default = "arn:aws:iam::aws:policy/AdministratorAccess"
+  type    = string
+}
+
 variable "aws_spot_fleet_service_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
   type    = string

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -301,7 +301,7 @@ variable "franklin_migrations_memory" {
   type = number
 }
 
-variable "aws_azavea_account_id" {
+variable "aws_raster_foundry_account_id" {
   type = string
 }
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,6 +3,9 @@ services:
   catalogs:
     image: "noaa-flood-catalogs:${GIT_COMMIT:-latest}"
 
+  pipeline:
+    image: "noaa-flood-pipeline:${GIT_COMMIT:-latest}"
+
   terraform:
     image: quay.io/azavea/terraform:0.12.29
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '2.4'
 services:
   catalogs:
-    build: ./catalogs
     image: noaa-flood-catalogs
+    build: ./catalogs
     environment:
       - AWS_PROFILE=${AWS_PROFILE:-noaa}
       - SENTINELHUB_OAUTH_ID
@@ -10,3 +10,7 @@ services:
     volumes:
       - ./catalogs:/opt/catalogs
       - $HOME/.aws:/root/.aws:ro
+
+  pipeline:
+    image: noaa-flood-pipeline
+    build: ./pipeline

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -27,6 +27,6 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
             -f docker-compose.yml \
             -f docker-compose.ci.yml \
-            build catalogs
+            build catalogs pipeline
     fi
 fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${NOAA_FLOOD_MAP_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Publish container images to Elastic Container Registry (ECR).
+"
+}
+
+if [[ -n "${GIT_COMMIT}" ]]; then
+    GIT_COMMIT="${GIT_COMMIT:0:7}"
+else
+    GIT_COMMIT="$(git rev-parse --short HEAD)"
+fi
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        if [[ -n "${NOAA_AWS_ECR_ENDPOINT}" ]]; then
+            # Evaluate the return value of the get-login subcommand, which
+            # is a docker login command with temporarily ECR credentials.
+            eval "$(aws ecr get-login --no-include-email)"
+
+            docker tag "noaa-flood-catalogs:${GIT_COMMIT}" \
+                "${NOAA_AWS_ECR_ENDPOINT}/noaa-flood-catalogs:${GIT_COMMIT}"
+            docker tag "noaa-flood-pipeline:${GIT_COMMIT}" \
+                "${NOAA_AWS_ECR_ENDPOINT}/noaa-flood-pipeline:${GIT_COMMIT}"
+
+            docker push "${NOAA_AWS_ECR_ENDPOINT}/noaa-flood-catalogs:${GIT_COMMIT}"
+            docker push "${NOAA_AWS_ECR_ENDPOINT}/noaa-flood-pipeline:${GIT_COMMIT}"
+        else
+            echo "ERROR: No NOAA_AWS_ECR_ENDPOINT variable defined."
+            exit 1
+        fi
+    fi
+fi


### PR DESCRIPTION
## Overview

Builds the `noaa-flood-pipeline` image and publishes it to ECR as part of the Jenkins build. Also creates ECR repositories for the `noaa-flood-pipeline` and `noaa-flood-catalogs` images.

## Notes

The `JenkinsAssumeCrossAccountDeployRole` role has been created and attached to the Raster Foundry Jenkins instance profile. It allows assuming the NOAA deploy role.

## Testing Instructions

- Confirm that the `noaa-flood-pipeline` and `noaa-flood-catalogs` images [are built successfully by Jenkins](http://jenkins.staging.rasterfoundry.com/job/Azavea/job/noaa-flood-mapping/view/change-requests/job/PR-96/7/) in `cibuild`.
- Confirm that both images are published to their respective ECR repositories, [`noaa-flood-catalogs`](https://console.aws.amazon.com/ecr/repositories/noaa-flood-catalogs/?region=us-east-1) and [`noaa-flood-pipeline`](https://console.aws.amazon.com/ecr/repositories/noaa-flood-pipeline/?region=us-east-1). Tag `7ffae0c` was pushed by this PR in [this Jenkins build](http://jenkins.staging.rasterfoundry.com/job/Azavea/job/noaa-flood-mapping/view/change-requests/job/PR-96/7/).

Resolves #64 